### PR TITLE
Fix out of bounds access to LinkerObjectTypeNames

### DIFF
--- a/oscar64/Linker.cpp
+++ b/oscar64/Linker.cpp
@@ -1014,6 +1014,7 @@ static const char * LinkerObjectTypeNames[] =
 	"BSS",
 	"HEAP",
 	"STACK",
+	"INLAY",
 	"START",
 	"END"
 };


### PR DESCRIPTION
One entry was missing, causing segmentation fault on some platforms.