### PR TITLE
Simplified Building Process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-
-
-sources = $(wildcard ../oscar64/*.cpp)
-objects = $(patsubst ../oscar64/%.cpp,%.o,$(sources))
+bin_dir = bin
+build_dir = build
+sources = $(wildcard oscar64/*.cpp)
+objects = $(patsubst oscar64/%.cpp,$(build_dir)/%.o,$(sources))
 
 CXX = c++
 CPPFLAGS = -g -O2 -std=c++11 -Wno-switch
  
- $(shell mkdir -p ../bin)
- 
+ $(shell mkdir -p $(bin_dir) $(build_dir))
+
 ifdef WINDIR
 	linklibs = -lpthread
 else
@@ -21,21 +21,21 @@ else
 	endif
 endif
  
-%.o: ../oscar64/%.cpp
+$(build_dir)/%.o: oscar64/%.cpp
 	$(CXX) -c $(CPPFLAGS) $< -o $@
 
-%.d: ../oscar64/%.cpp
+$(build_dir)/%.d: oscar64/%.cpp
 	@set -e; rm -f $@; \
 	$(CC) -MM $(CPPFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 
-../bin/oscar64 : $(objects)
-	$(CXX) $(CPPFLAGS) $(linklibs) $(objects) -o ../bin/oscar64
+$(bin_dir)/oscar64 : $(objects)
+	$(CXX) $(CPPFLAGS) $(linklibs) $(objects) -o $(bin_dir)/oscar64
 
 .PHONY : clean
 clean :
-	-rm *.o *.d ../bin/oscar64
+	-rm $(build_dir)/*.o $(build_dir)/*.d $(bin_dir)/oscar64
 
 ifeq ($(UNAME_S), Darwin)
 


### PR DESCRIPTION
So just thought id put in the rather small effort of making the build process more simpler so instead of the user having to cd into build and running make from there the Makefile is instead placed in root and build files like .o and .d can be found inside build while the binary is found inside the bin folder.
If there is any isuses with that or just other things i missed please tell me!
(The README was not changed because i honestly forgot about it)