### PR TITLE
Fixed warning

### DIFF
--- a/oscar64/Scanner.cpp
+++ b/oscar64/Scanner.cpp
@@ -765,7 +765,7 @@ void Scanner::NextPreToken(void)
 				{
 					mToken = TK_STRING;
 					int i = 0;
-					while (mTokenString[i] = def->mString[i])
+					while ((mTokenString[i] = def->mString[i]))
 						i++;
 					return;
 				}


### PR DESCRIPTION
c++ -c -g -O2 -std=c++11 -Wno-switch ../oscar64/oscar64.cpp -o oscar64.o ../oscar64/Scanner.cpp:768:29: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                                        while (mTokenString[i] = def->mString[i])
                                               ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
../oscar64/Scanner.cpp:768:29: note: place parentheses around the assignment to silence this warning
                                        while (mTokenString[i] = def->mString[i])
                                                               ^
                                               (                                )
../oscar64/Scanner.cpp:768:29: note: use '==' to turn this assignment into an equality comparison
                                        while (mTokenString[i] = def->mString[i])
                                                               ^
                                                               ==
1 warning generated.