### PR TITLE
added standard c++ method c_str to opp::string that calls cstr method.

### DIFF
--- a/include/opp/string.cpp
+++ b/include/opp/string.cpp
@@ -229,6 +229,10 @@ string & string::operator+=(char c)
 	return *this;
 }
 
+inline const char * string::c_str(void) const
+{
+	return this->tocstr();
+}
 
 inline const char * string::tocstr(void) const
 {


### PR DESCRIPTION
This should help Intellisense while allowing code that still uses the cstr method to work.