### PR TITLE
Update kernalio.h

### DIFF
--- a/include/c64/kernalio.h
+++ b/include/c64/kernalio.h
@@ -1,4 +1,4 @@
-#ifndef C64_KERNALIO_H
+
 #ifndef C64_KERNALIO_H
 
 // Error and status codes returned by krnio_status


### PR DESCRIPTION
Removed extra "#ifndef C64_KERNALIO_H" to fix "unterminated conditional directive" error.