### PR TITLE
Windows: support of GCC (MinGW)

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -17,8 +17,11 @@ else
 
 		linklibs = -lpthread
   	else
+		# MSVC
 		linklibs = -lrt -lpthread
-	endif
+		# MinGW
+		#linklibs = -lversion -lpthread
+      endif
 endif
  
 %.o: ../oscar64/%.cpp
@@ -31,7 +34,7 @@ endif
 	rm -f $@.$$$$
 
 ../bin/oscar64 : $(objects)
-	$(CXX) $(CPPFLAGS) $(linklibs) $(objects) -o ../bin/oscar64
+	$(CXX) $(CPPFLAGS) $(objects) $(linklibs) -o ../bin/oscar64
 
 .PHONY : clean
 clean :

--- a/make/makefile
+++ b/make/makefile
@@ -16,12 +16,12 @@ else
 	ifeq ($(UNAME_S), Darwin)
 
 		linklibs = -lpthread
-  	else
+	else
 		# MSVC
 		linklibs = -lrt -lpthread
 		# MinGW
 		#linklibs = -lversion -lpthread
-      endif
+	endif
 endif
  
 %.o: ../oscar64/%.cpp

--- a/oscar64/oscar64.cpp
+++ b/oscar64/oscar64.cpp
@@ -567,9 +567,11 @@ int main(int argc, const char** argv)
 {
 #if 1
 #ifdef _WIN32
+#ifndef __GNUC__
 #ifndef _DEBUG
 	__try 
 	{
+#endif
 #endif
 #endif
 #endif
@@ -577,12 +579,14 @@ int main(int argc, const char** argv)
 
 #if 1
 #ifdef _WIN32
+#ifndef __GNUC__
 #ifndef _DEBUG
 }
 	__except (seh_filter(GetExceptionCode(), GetExceptionInformation()))
 	{
 		return 30;
 	}
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
Wrapped MSVC-specific code, prepared list of libs for GCC, fixed order of objects/libs which matters for GCC.