### PR TITLE
Standardise Implementation of get_s C function

### DIFF
--- a/include/stdio.c
+++ b/include/stdio.c
@@ -1,6 +1,7 @@
 #include "stdio.h"
 #include "conio.h"
 #include "stdlib.h"
+#include "stdbool.h"
 
 void putchar(char c)
 {
@@ -29,13 +30,29 @@ char * gets(char * str)
 
 char * gets_s(char * str, size_t n)
 {
+	if (str == NULL)
+		return NULL;
+
+	if (n == 0 || n == 1)
+		return NULL;
+	str[0] = '\0';
 	char i = 0, t = n - 1;
+	bool isTruncated = false;
+
 	while ((char ch = getpch()) != '\n')
 	{
 		if (i < t)
 			str[i++] = ch;
+		else
+		{
+			isTruncated = true;
+			break;
+		}
 	}
 	str[i] = 0;
+
+	if (isTruncated)
+		return NULL;
 	return str;
 }
 

--- a/include/stdio.c
+++ b/include/stdio.c
@@ -1,7 +1,6 @@
 #include "stdio.h"
 #include "conio.h"
 #include "stdlib.h"
-#include "stdbool.h"
 
 void putchar(char c)
 {

--- a/include/stdio.c
+++ b/include/stdio.c
@@ -33,25 +33,19 @@ char * gets_s(char * str, size_t n)
 	if (str == NULL)
 		return NULL;
 
-	if (n == 0 || n == 1)
+	if (n < 2)
 		return NULL;
-	str[0] = '\0';
 	char i = 0, t = n - 1;
-	bool isTruncated = false;
 
 	while ((char ch = getpch()) != '\n')
 	{
 		if (i < t)
-			str[i++] = ch;
-		else
-		{
-			isTruncated = true;
-			break;
-		}
+			str[i] = ch;
+		++i;
 	}
-	str[i] = 0;
+	str[(i < t) ? i : t] = '\0';
 
-	if (isTruncated)
+	if (i > t)
 		return NULL;
 	return str;
 }


### PR DESCRIPTION
- Changes from being mostly assembly to be based upon a C version.
- Adds the additional error conditions for get_s: truncation and too small buffer as defined in https://en.cppreference.com/w/c/io/gets .