### PR TITLE
kbhit variant for CBM PET

### DIFF
--- a/include/conio.c
+++ b/include/conio.c
@@ -268,11 +268,20 @@ char getpch(void)
 
 char kbhit(void)
 {
+#if defined(__CBMPET__)
+	return __asm
+	{
+		ldx $97
+		inx
+		stx	accu
+	};
+#else
 	return __asm
 	{
 		lda $c6
 		sta	accu
 	};
+#endif
 }
 
 char getche(void)

--- a/include/conio.c
+++ b/include/conio.c
@@ -271,9 +271,8 @@ char kbhit(void)
 #if defined(__CBMPET__)
 	return __asm
 	{
-		ldx $97
-		inx
-		stx	accu
+		lda $9e
+		sta	accu
 	};
 #else
 	return __asm


### PR DESCRIPTION
kbhit() doesn't work on PET machines, as the used zeropage location doesn't contain the desired info. I propose this alternate solution, which doesn't look at the buffer but the actual kbhit status. Little test program with an external implementation:
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <conio.h>

char pet_kbhit(void)
{
    return __asm
	{
            ldx $97
            inx
            stx	accu
	};
}


unsigned char f()
{
    if( pet_kbhit() ) {
        printf("HIT!\n");
        return 0;
    } else {
        return 1;
    }
}

int main(void)
{
    unsigned char change ;

    do {
        change = f();
    } while( change );
    getch();

    return 0;
}
```