### PR TITLE
Implement gotoxy for PET

### DIFF
--- a/include/conio.c
+++ b/include/conio.c
@@ -353,6 +353,7 @@ void textcursor(bool show)
 void gotoxy(char cx, char cy)
 {
 #ifdef __CBMPET__
+    /* This is inspired by the cc65 source code from pet/cputc.s */    
 #define CURS_X $c6
 #define CURS_Y $d8
 #define SCREEN_PTR $c4

--- a/include/conio.c
+++ b/include/conio.c
@@ -175,7 +175,7 @@ void petplot(char cx, char cy)
         {
             /* BASIC4 80-col */
             ldx cx
-            ldx cy
+            ldy cy
             stx $e2
             sty $e0
             jsr 0xe05f
@@ -186,7 +186,7 @@ void petplot(char cx, char cy)
         {
             /* BASIC4 40-col */
             ldx cx
-            ldx cy
+            ldy cy
             stx $c6
             sty $d8
             jsr 0xe07f
@@ -197,7 +197,7 @@ void petplot(char cx, char cy)
         {
             /* BASIC2 */
             ldx cx
-            ldx cy
+            ldy cy
             stx $c6
             sty $d8
             jsr 0xe25d
@@ -208,7 +208,7 @@ void petplot(char cx, char cy)
         {
             /* BASIC1 */
             ldx cx
-            ldx cy
+            ldy cy
             stx $e2
             sty $f5
             jsr 0xe5db

--- a/include/conio.c
+++ b/include/conio.c
@@ -134,8 +134,77 @@ __asm bsinit
 #elif defined(__CBMPET__)
 #define bsout	0xffd2
 #define bsin	0xffe4
-__asm bsplot{
-    /* no equivalent on PET */
+/* This is inspired by the cc65 source code from pet/cputc.s */    
+#define CURS_X $c6
+#define CURS_Y $d8
+#define SCREEN_PTR $c4
+#define SCR_LINELEN $d5
+__asm bsplot
+{
+	sty CURS_X
+	stx CURS_Y
+plot:	ldy CURS_Y
+	lda ScrLo,y
+	sta SCREEN_PTR
+	lda ScrHi,y
+	ldy SCR_LINELEN
+	cpy #40+1
+	bcc col80
+	asl SCREEN_PTR              /* 80 column mode */
+	rol
+col80:	ora #$80                    /* Screen at $8000 */
+	sta SCREEN_PTR+1
+	rts
+ScrLo:	byt 0x00
+	byt 0x28
+	byt 0x50
+	byt 0x78
+	byt 0xA0
+	byt 0xC8
+	byt 0xF0
+	byt 0x18
+	byt 0x40
+	byt 0x68
+	byt 0x90
+	byt 0xB8
+	byt 0xE0
+	byt 0x08
+	byt 0x30
+	byt 0x58
+	byt 0x80
+	byt 0xA8
+	byt 0xD0
+	byt 0xF8
+	byt 0x20
+	byt 0x48
+	byt 0x70
+	byt 0x98
+	byt 0xC0
+ScrHi:	byt 0x00
+	byt 0x00
+	byt 0x00
+	byt 0x00
+	byt 0x00
+	byt 0x00
+	byt 0x00
+	byt 0x01
+	byt 0x01
+	byt 0x01
+	byt 0x01
+	byt 0x01
+	byt 0x01
+	byt 0x02
+	byt 0x02
+	byt 0x02
+	byt 0x02
+	byt 0x02
+	byt 0x02
+	byt 0x02
+	byt 0x03
+	byt 0x03
+	byt 0x03
+	byt 0x03
+	byt 0x03
 }
 __asm bsinit
 {
@@ -352,40 +421,6 @@ void textcursor(bool show)
 
 void gotoxy(char cx, char cy)
 {
-#ifdef __CBMPET__
-    /* This is inspired by the cc65 source code from pet/cputc.s */    
-#define CURS_X $c6
-#define CURS_Y $d8
-#define SCREEN_PTR $c4
-#define SCR_LINELEN $d5
-
-    static const char ScrLo[] = { 0x00, 0x28, 0x50, 0x78, 0xA0, 0xC8, 0xF0, 0x18,
-                                  0x40, 0x68, 0x90, 0xB8, 0xE0, 0x08, 0x30, 0x58,
-                                  0x80, 0xA8, 0xD0, 0xF8, 0x20, 0x48, 0x70, 0x98,
-                                  0xC0 };
-
-    static const char ScrHi[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-                                  0x01, 0x01, 0x01, 0x01, 0x01, 0x02, 0x02, 0x02,
-                                  0x02, 0x02, 0x02, 0x02, 0x03, 0x03, 0x03, 0x03,
-                                  0x03 };
-    __asm {
-            lda     cx
-            sta     CURS_X
-            lda     cy
-            sta     CURS_Y
-            ldy     CURS_Y
-            lda     ScrLo,y
-            sta     SCREEN_PTR
-            lda     ScrHi,y
-            ldy     SCR_LINELEN
-            cpy     #40+1
-            bcc     col80
-            asl     SCREEN_PTR                     /* 80 column mode */
-            rol
-    col80:  ora     #$80                    /* Screen at $8000 */
-            sta     SCREEN_PTR+1
-    }
-#else
 	__asm
 	{
 		ldx	cy
@@ -393,7 +428,6 @@ void gotoxy(char cx, char cy)
 		clc
 		jsr bsplot
 	}
-#endif
 }
 
 void textcolor(char c)


### PR DESCRIPTION
PET machine would crash when calling gotoxy() or any time bsplot is called. This is different on PETs compared to C64 et al. 

The corresponding function is in the Editor ROM, which is different between BASIC V1, V2 and V4. And even 40 column vs 80 column PETs!

The attached patch will hopefully run on the above PETs, but I am not sure it will work on 8x96 machines. Tested on 3016 with Basic V4. The detect_basic routine can also be used to e.g. later implement support for DLOAD and other DOS calls if on V4 machines?