### PR TITLE
prepare output directory also to build only the compiler

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -38,7 +38,7 @@ else
 endif
 
 
-all: --prep-build-dir compiler samples check
+all: compiler samples check
 
 
 $(srcdir)/%.o: $(project_dir)/oscar64/%.cpp
@@ -56,7 +56,7 @@ $(srcdir)/%.d: $(project_dir)/oscar64/%.cpp
 	$(RM) $@.$$$$
 
 
-compiler: $(objects)
+compiler: --prep-build-dir $(objects)
 	@$(MKDIR_PARENT) $(srcdir)
 	@echo "Linking compiler..."
 	$(CXX) $(CPPFLAGS) $(objects) $(linklibs) -o $(project_dir)/bin/oscar64


### PR DESCRIPTION
Hi, I created a compilable package for Slackware. During the tests, I noticed that if I try to compile only the executable with the command 
```
make -C make compiler 
```
fails because the output directory **bin** is not created. 
This little contribution solves the problem.