### PR TITLE
Allow usage of GCC in Windows

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -22,18 +22,22 @@ includedir = $(prefix)/include
 
  
 ifdef WINDIR
-	linklibs = -lpthread
+	UNAME_S := $(shell uname -s 2>/dev/null || echo "Windows")
+
+	ifneq ($(findstring MINGW,$(UNAME_S)),)
+		# MinGW
+		linklibs = -lversion -lpthread
+	else
+		# Native Windows (MSVC or other)
+		linklibs = -lpthread
+	endif
 else
 	UNAME_S := $(shell uname -s)
 	
 	ifeq ($(UNAME_S), Darwin)
-
 		linklibs = -lpthread
 	else
-		# MSVC
 		linklibs = -lrt -lpthread
-		# MinGW
-		#linklibs = -lversion -lpthread
 	endif
 endif
 


### PR DESCRIPTION
I have recently discovered your compiler and I am completely overwhelmed by its performance. I have started to port a project I'm working on for a long time from CC65 to Oscar64. I discovered a minor issue when using definitions within ASM code and decided to implement a small enhancement. The first step was to make it possible to compile Oscar with my current development environment (MINGW/GCC in Windows).

I added a check for MINGW to the makefile. This allows the MINGW/GCC compiler toolchain to be used in Windows. I also removed some commented-out code that seems unnecessary. I tested the changes with Windows and Linux.