### PR TITLE
Fix build on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,12 @@ set_target_properties(oscar64 PROPERTIES
 
 # Set debug and release configurations
 target_compile_definitions(oscar64 PRIVATE $<$<CONFIG:Debug>:_DEBUG;_CONSOLE> $<$<CONFIG:Release>:NDEBUG;_CONSOLE>)
-target_compile_options(oscar64 PRIVATE $<$<CONFIG:Debug>:/W3 /WX> $<$<CONFIG:Release>:/O2 /W3>)
+
+if (WIN32)
+    target_compile_options(oscar64 PRIVATE $<$<CONFIG:Debug>:/W3 /WX> $<$<CONFIG:Release>:/O2 /W3>)
+else ()
+    target_compile_options(oscar64 PRIVATE -Wall)
+endif ()
 
 # Post-build steps (only for Release builds)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
The CMake script hardcodes the /W3 and /WX switches. This prevents from building the project on anything that is not Windows.

In the PR, I've surrounded hardcoded CL.EXE switches with `if (WIN32)`, so that the project builds on Linux. Equivalent of /W3 would be -Wall, and equivalent of /WX is -Werror, but the second one is not used, because there are too many warnings, so using -Werror would prevent the project from compiling.