### PR TITLE
String lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,4 @@ make/oscar64
 *.idb
 oscar64/Releasex64/oscar64.vcxproj.FileListAbsolute.txt
 /oscar64/Debugx64
+.clang-format

--- a/autotest/memchrtest.c
+++ b/autotest/memchrtest.c
@@ -1,0 +1,103 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+char testmem[2000];
+
+int main(void)
+{
+	// Test memchr with basic functionality
+	assert(memcmp(memchr("hello", 'h', 5), "hello", 5) == 0);
+	assert(memcmp(memchr("hello", 'e', 5), "ello", 4) == 0);
+	assert(memcmp(memchr("hello", 'l', 5), "llo", 3) == 0);  // finds first 'l'
+	assert(memcmp(memchr("hello", 'o', 5), "o", 1) == 0);
+	assert(memchr("hello", 'x', 5) == 0);
+	
+	// Test memchr with size limits
+	assert(memchr("hello", 'o', 4) == 0);      // 'o' is at position 4, but size is 4 (0-3)
+	assert(memcmp(memchr("hello", 'l', 3), "llo", 3) == 0);  // finds 'l' at position 2 within size 3
+	assert(memchr("hello", 'e', 1) == 0);      // 'e' is at position 1, but size is 1 (0 only)
+	
+	// Test memchr with zero size
+	assert(memchr("hello", 'h', 0) == 0);
+	assert(memchr("hello", 'x', 0) == 0);
+	
+	// Test memchr with null character
+	assert(*((char*)memchr("hello", '\0', 6)) == '\0');    // finds null terminator
+	assert(memchr("hello", '\0', 5) == 0);     // null is at position 5, size is 5 (0-4)
+	
+	// Test memchr with single byte
+	assert(memcmp(memchr("a", 'a', 1), "a", 1) == 0);
+	assert(memchr("a", 'b', 1) == 0);
+	
+	// Test memchr with repeated characters
+	assert(memcmp(memchr("aaaaaa", 'a', 6), "aaaaaa", 6) == 0);  // finds first occurrence
+	assert(memcmp(memchr("abcabc", 'a', 6), "abcabc", 6) == 0);  // finds first 'a'
+	assert(memcmp(memchr("abcabc", 'b', 6), "bcabc", 5) == 0);   // finds first 'b'
+	assert(memcmp(memchr("abcabc", 'c', 6), "cabc", 4) == 0);    // finds first 'c'
+	
+	// Test memchr with special characters and binary data
+	assert(memcmp(memchr("hello world", ' ', 11), " world", 6) == 0);
+	assert(memcmp(memchr("a.b,c;d", '.', 7), ".b,c;d", 6) == 0);
+	assert(memcmp(memchr("a.b,c;d", ',', 7), ",c;d", 4) == 0);
+	assert(memcmp(memchr("a.b,c;d", ';', 7), ";d", 2) == 0);
+	
+	// Test memchr with binary data (including zeros)
+	testmem[0] = 'a';
+	testmem[1] = '\0';
+	testmem[2] = 'b';
+	testmem[3] = '\0';
+	testmem[4] = 'c';
+	
+	assert(memchr(testmem, 'a', 5) == testmem);
+	assert(memchr(testmem, '\0', 5) == testmem + 1);  // finds first null
+	assert(memchr(testmem, 'b', 5) == testmem + 2);
+	assert(memchr(testmem, 'c', 5) == testmem + 4);
+	assert(memchr(testmem, 'd', 5) == 0);
+	
+	// Test memchr with different byte values
+	for(int i = 0; i < 256; i++)
+	{
+		testmem[i] = (unsigned char)i;
+	}
+	
+	// Test finding various byte values
+	assert(memchr(testmem, 0, 256) == testmem);        // byte 0 at position 0
+	assert(memchr(testmem, 1, 256) == testmem + 1);    // byte 1 at position 1
+	assert(memchr(testmem, 127, 256) == testmem + 127); // byte 127 at position 127
+	assert(memchr(testmem, 255, 256) == testmem + 255); // byte 255 at position 255
+	
+	// Test memchr with size smaller than target position
+	assert(memchr(testmem, 100, 50) == 0);   // byte 100 is at position 100, but size is 50
+	assert(memchr(testmem, 100, 101) == testmem + 100); // finds it with adequate size
+	
+	// Test memchr with longer memory region
+	for(int i = 0; i < 1000; i++)
+	{
+		testmem[i] = 'a' + (i & 7);
+	}
+	
+	// Test memchr with pattern
+	assert(memchr(testmem, 'a', 1000) == testmem);      // first 'a' at start
+	assert(memchr(testmem, 'b', 1000) == testmem + 1);  // first 'b' at position 1
+	assert(memchr(testmem, 'h', 1000) == testmem + 7);  // first 'h' at position 7
+	assert(memchr(testmem, 'z', 1000) == 0);            // 'z' not in pattern
+	
+	// Test memchr starting from middle of buffer
+	assert(memchr(testmem + 100, 'a', 900) == testmem + 104);  // next 'a' after position 100
+	assert(memchr(testmem + 100, 'c', 900) == testmem + 106);  // next 'c' after position 100
+	
+	// Test memchr with exact size to find character
+	assert(memchr(testmem, 'h', 8) == testmem + 7);   // 'h' at position 7, size exactly 8
+	assert(memchr(testmem, 'h', 7) == 0);             // 'h' at position 7, size only 7 (0-6)
+	
+	// Test memchr character not found in range
+	for(int i = 0; i < 100; i++)
+	{
+		testmem[i] = 'x';  // fill with 'x'
+	}
+	assert(memchr(testmem, 'y', 100) == 0);  // 'y' not found
+	assert(memchr(testmem, 'x', 100) == testmem);  // 'x' found at start
+
+	return 0;
+}

--- a/autotest/sscanftest.c
+++ b/autotest/sscanftest.c
@@ -1,0 +1,134 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <math.h>
+
+#define EPSILON 0.0001
+
+int scan_i(const char * fmt, const char * tst) {
+	int val;
+
+	sscanf(tst, fmt, &val);
+	printf(fmt, val);
+	puts("\n");
+
+	return val;
+}
+
+long scan_l(const char * fmt, const char * tst) {
+	long val;
+
+	sscanf(tst, fmt, &val);
+	printf(fmt, val);
+	puts("\n");
+
+	return val;
+}
+
+unsigned int scan_ui(const char * fmt, const char * tst) {
+	unsigned int val;
+
+	sscanf(tst, fmt, &val);
+	printf(fmt, val);
+	puts("\n");
+
+	return val;
+}
+
+unsigned long scan_ul(const char * fmt, const char * tst) {
+	unsigned long val;
+
+	sscanf(tst, fmt, &val);
+	printf(fmt, val);
+	puts("\n");
+
+	return val;
+}
+
+float scan_f(const char * fmt, const char * tst) {
+	float val;
+
+	sscanf(tst, fmt, &val);
+	printf(fmt, val);
+	puts("\n");
+
+	return val;
+}
+
+bool closeTo(float a, float b) {
+	while (a < -1.0 || a > 1.0) a /= 10.0;
+	while (b < -1.0 || b > 1.0) b /= 10.0;
+
+	return fabs(a - b) < EPSILON;
+}
+
+int main(void)
+{
+	assert(scan_i("%d", "0") == 0);
+	assert(scan_i("%d", "1") == 1);
+	assert(scan_i("%d", "-1") == -1);
+	assert(scan_i("%d", "12") == 12);
+	assert(scan_i("%d", "123") == 123);
+	assert(scan_i("%d", "1234") == 1234);
+	assert(scan_i("%d", "12345") == 12345);
+	assert(scan_i("%d", "-12345") == -12345);
+	assert(scan_i("%d", "32767") == 32767);
+	assert(scan_i("%d", "-32768") == -32768);
+
+	assert(scan_l("%ld", "0") == 0l);
+	assert(scan_l("%ld", "1") == 1l);
+	assert(scan_l("%ld", "-1") == -1l);
+	assert(scan_l("%ld", "12") == 12l);
+	assert(scan_l("%ld", "123") == 123l);
+	assert(scan_l("%ld", "1234") == 1234l);
+	assert(scan_l("%ld", "12345") == 12345l);
+	assert(scan_l("%ld", "-12345") == -12345l);
+	assert(scan_l("%ld", "32767") == 32767l);
+	assert(scan_l("%ld", "-32768") == -32768l);
+	assert(scan_l("%ld", "2147483647") == 2147483647l);
+	assert(scan_l("%ld", "-2147483648") == -2147483648l);
+
+	assert(scan_ui("%u", "0") == 0);
+	assert(scan_ui("%u", "1") == 1);
+	assert(scan_ui("%u", "12") == 12);
+	assert(scan_ui("%u", "123") == 123);
+	assert(scan_ui("%u", "1234") == 1234);
+	assert(scan_ui("%u", "12345") == 12345);
+	assert(scan_ui("%u", "32767") == 32767);
+	assert(scan_ui("%u", "32768") == 32768);
+	assert(scan_ui("%u", "65535") == 65535);
+	assert(scan_ui("%x", "0") == 0);
+	assert(scan_ui("%x", "49BF") == 0x49bf);
+	assert(scan_ui("%x", "FFFF") == 0xffff);
+
+	assert(scan_ul("%lu", "000") == 0l);
+	assert(scan_ul("%lu", "001") == 1l);
+	assert(scan_ul("%lu", "012") == 12l);
+	assert(scan_ul("%lu", "123") == 123l);
+	assert(scan_ul("%lu", "1234") == 1234l);
+	assert(scan_ul("%lu", "12345") == 12345l);
+	assert(scan_ul("%lu", "32767") == 32767l);
+	assert(scan_ul("%lu", "2147483647") == 2147483647l);
+	assert(scan_ul("%lu", "4294967295") == 4294967295l);
+	assert(scan_ul("%lx", "000") == 0);
+	assert(scan_ul("%lx", "3576FBCD") == 0x3576fbcdl);
+	assert(scan_ul("%lx", "FFFFFFFF") == 0xffffffffl);
+
+	assert(closeTo(scan_f("%f", "0.000000"), 0.));
+	assert(closeTo(scan_f("%f", "1.000000"), 1.));
+	assert(closeTo(scan_f("%f", "-1.000000"), -1.));
+	assert(closeTo(scan_f("%f", "12.000000"), 12.));
+	assert(closeTo(scan_f("%f", "123.000000"), 123.));
+	assert(closeTo(scan_f("%f", "1234.000000"), 1234.));
+	assert(closeTo(scan_f("%f", "12345.000000"), 12345.));
+	assert(closeTo(scan_f("%f", "123456.000000"), 123456.));
+	assert(closeTo(scan_f("%f", "1234567.000000"), 1234567.));
+	assert(closeTo(scan_f("%f", "0.100000"), 0.1));
+	assert(closeTo(scan_f("%f", "0.010000"), 0.01));
+	assert(closeTo(scan_f("%f", "0.001000"), 0.001));
+	assert(closeTo(scan_f("%f", "0.000100"), 0.0001));
+	assert(closeTo(scan_f("%f", "0.000010"), 0.00001));
+	assert(closeTo(scan_f("%f", "0.000001"), 0.000001));
+
+	return 0;
+}

--- a/autotest/stdlibtest.c
+++ b/autotest/stdlibtest.c
@@ -64,10 +64,68 @@ void heapcheck(void)
 	}
 }
 
+void callocckeck(void) {
+	const int ALLOC_COUNT = 4;
+	const int MAX_SIZE = 8;
+
+    int i, j;
+    int sizes[ALLOC_COUNT];
+    char str[ALLOC_COUNT][MAX_SIZE];
+    void *ptr[ALLOC_COUNT];
+
+    for (i = 0; i < ALLOC_COUNT; i++)
+    {
+        sizes[i] = abs(rand() % ALLOC_COUNT) * 2;
+
+		for (j=0; j < sizes[i]-1; j++) {
+			str[i][j] = 'a' + (abs(rand()) % 26);
+		}
+
+		str[i][sizes[i]-1] = '\0'; 
+	}
+
+    for (i = 0; i < ALLOC_COUNT; i++)
+    {
+        ptr[i] = calloc(sizes[i] / 2, 2);
+
+        if (ptr[i] == NULL)
+        {
+			exit(-4);
+		}
+
+        strcpy(ptr[i], str[i]);
+    }
+
+    for (i = 0; i < ALLOC_COUNT; i++)
+    {
+        if (strcmp(ptr[i], str[i]) != 0)
+        {
+			exit(-5);
+        }
+    }
+
+    for (i = 0; i < ALLOC_COUNT; i++)
+    {
+        free(ptr[i]);
+    }
+}
+
+void divcheck(void) {
+	div_t d = div(10, 3);
+	if (d.quot != 3 || d.rem != 1)
+		exit(-6);
+
+	ldiv_t ld = ldiv(10, 3);
+	if (ld.quot != 3 || ld.rem != 1)
+		exit(-7);
+}
+
 int main(void)
 {
 	numchecks();
 	heapcheck();
+	callocckeck();
+	divcheck();
 	
 	return 0;
 }

--- a/autotest/strcattest.c
+++ b/autotest/strcattest.c
@@ -1,0 +1,135 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+char dest[2000], src[2000];
+
+int main(void)
+{
+	// Test strcat with basic strings
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "hello");
+	strcat(dest, " world");
+	assert(strcmp(dest, "hello world") == 0);
+
+	// Test strcat with empty string
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "test");
+	strcat(dest, "");
+	assert(strcmp(dest, "test") == 0);
+
+	// Test strcat to empty string
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "");
+	strcat(dest, "append");
+	assert(strcmp(dest, "append") == 0);
+
+	// Test strcat multiple concatenations
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "a");
+	strcat(dest, "b");
+	strcat(dest, "c");
+	strcat(dest, "d");
+	assert(strcmp(dest, "abcd") == 0);
+
+	// Test strcat with single characters
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "x");
+	strcat(dest, "y");
+	assert(strcmp(dest, "xy") == 0);
+
+	// Test strcat with longer strings
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "beginning");
+	strcat(dest, "_middle_");
+	strcat(dest, "end");
+	assert(strcmp(dest, "beginning_middle_end") == 0);
+
+	// Test strncat with basic functionality
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "hello");
+	strncat(dest, " world", 6);
+	assert(memcmp(dest, "hello world\0#", 13) == 0);
+	
+	// Test strncat with partial concatenation
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "hello");
+	strncat(dest, " world", 3);
+	assert(memcmp(dest, "hello wo\0#", 10) == 0);
+
+	// Test strncat with zero length
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "original");
+	strncat(dest, "ignored", 0);
+	assert(memcmp(dest, "original\0#", 10) == 0);
+
+	// Test strncat with exact length
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "test");
+	strncat(dest, "1234", 4);
+	assert(memcmp(dest, "test1234\0#", 10) == 0);
+
+	// Test strncat where n is larger than source
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "base");
+	strncat(dest, "add", 10);
+	assert(memcmp(dest, "baseadd\0#", 9) == 0);
+
+	// Test strncat with empty source
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "keep");
+	strncat(dest, "", 5);
+	assert(memcmp(dest, "keep\0#", 6) == 0);
+
+	// Test strncat with empty destination
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "");
+	strncat(dest, "new", 3);
+	assert(memcmp(dest, "new\0#", 4) == 0);
+
+	// Test strncat with single character
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "a");
+	strncat(dest, "bcdef", 1);
+	assert(memcmp(dest, "ab\0#", 4) == 0);
+
+	// Test strncat with long strings
+	memset(dest, '#', sizeof(dest));
+	for (int i = 0; i < 500; i++)
+	{
+		src[i] = 'a' + (i & 7);
+	}
+	src[500] = '\0';
+
+	strcpy(dest, "prefix_");
+	strcat(dest, src);
+	assert(strlen(dest) == 507); // 7 + 500
+	assert(strncmp(dest, "prefix_", 7) == 0);
+	assert(memcmp(dest + 7, src, 500) == 0);
+
+	// Test strncat with long strings
+	memset(dest, '#', sizeof(dest));
+	strcpy(dest, "start_");
+	strncat(dest, src, 100);
+	assert(strlen(dest) == 106); // 6 + 100
+	assert(strncmp(dest, "start_", 6) == 0);
+	assert(strncmp(dest + 6, src, 100) == 0); 
+	assert(dest[106] == '\0'); // ensure null termination
+	
+	// Test strncat with partial long string
+	memset(dest, '#', sizeof(dest));
+	for (int i = 0; i < 1000; i++)
+	{
+		src[i] = 'x' + (i & 3);
+	}
+	src[1000] = '\0';
+
+	strcpy(dest, "begin");
+	strncat(dest, src, 50);
+	assert(strlen(dest) == 55); // 5 + 50
+	assert(strncmp(dest, "begin", 5) == 0);
+	assert(strncmp(dest + 5, src, 50) == 0);
+	assert(dest[55] == '\0'); // ensure null termination
+
+	return 0;
+}

--- a/autotest/strchrtest.c
+++ b/autotest/strchrtest.c
@@ -1,0 +1,111 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+char teststr[2000];
+
+int main(void)
+{
+	// Test strchr with basic functionality
+	assert(strcmp(strchr("hello", 'h'), "hello") == 0);
+	assert(strcmp(strchr("hello", 'e'), "ello") == 0);
+	assert(strcmp(strchr("hello", 'l'), "llo") == 0);  // finds first 'l'
+	assert(strcmp(strchr("hello", 'o'), "o") == 0);
+	assert(strchr("hello", 'x') == nullptr);
+	
+	// Test strchr with null character
+	strcpy(teststr, "hello");
+	assert(strchr(teststr, '\0') == teststr + 5); // should point to end of string
+	
+	// Test strchr with empty string
+	assert(strchr("", 'a') == nullptr);
+	strcpy(teststr, "");
+	assert(strchr(teststr, '\0') == teststr); // should point to start of
+	
+	// Test strchr with single character string
+	assert(strcmp(strchr("a", 'a'), "a") == 0);
+	assert(strchr("a", 'b') == nullptr);
+	strcpy(teststr, "a");
+	assert(strchr(teststr, '\0') == teststr + 1); // should point to end of single character string
+	
+	// Test strchr with repeated characters
+	assert(strcmp(strchr("aaaaaa", 'a'), "aaaaaa") == 0);  // finds first occurrence
+	assert(strcmp(strchr("abcabc", 'a'), "abcabc") == 0);  // finds first 'a'
+	assert(strcmp(strchr("abcabc", 'b'), "bcabc") == 0);   // finds first 'b'
+	assert(strcmp(strchr("abcabc", 'c'), "cabc") == 0);    // finds first 'c'
+	
+	// Test strchr with special characters
+	assert(strcmp(strchr("hello world", ' '), " world") == 0);
+	assert(strcmp(strchr("a.b,c;d", '.'), ".b,c;d") == 0);
+	assert(strcmp(strchr("a.b,c;d", ','), ",c;d") == 0);
+	assert(strcmp(strchr("a.b,c;d", ';'), ";d") == 0);
+	
+	// Test strrchr with basic functionality
+	assert(strcmp(strrchr("hello", 'h'), "hello") == 0);
+	assert(strcmp(strrchr("hello", 'e'), "ello") == 0);
+	assert(strcmp(strrchr("hello", 'l'), "lo") == 0);    // finds last 'l'
+	assert(strcmp(strrchr("hello", 'o'), "o") == 0);
+	assert(strrchr("hello", 'x') == nullptr);
+	
+	// Test strrchr with null character
+	strcpy(teststr, "hello");
+	assert(strrchr(teststr, '\0') == teststr + 5); // should point to end of string
+	
+	// Test strrchr with empty string
+	assert(strrchr("", 'a') == nullptr);
+	strcpy(teststr, "");
+	assert(strrchr(teststr, '\0') == teststr); // should point to start
+	
+	// Test strrchr with single character string
+	assert(strcmp(strrchr("a", 'a'), "a") == 0);
+	assert(strrchr("a", 'b') == nullptr);	// Test strrchr with repeated characters
+	assert(strcmp(strrchr("aaaaaa", 'a'), "a") == 0);      // finds last 'a'
+	assert(strcmp(strrchr("abcabc", 'a'), "abc") == 0);    // finds last 'a'
+	assert(strcmp(strrchr("abcabc", 'b'), "bc") == 0);     // finds last 'b'
+	assert(strcmp(strrchr("abcabc", 'c'), "c") == 0);      // finds last 'c'
+	
+	// Test strrchr with special characters
+	assert(strcmp(strrchr("hello world test", ' '), " test") == 0);
+	assert(strcmp(strrchr("a.b.c.d", '.'), ".d") == 0);
+	assert(strcmp(strrchr("a,b,c,d", ','), ",d") == 0);
+	
+	// Test with longer strings
+	strcpy(teststr, "this is a test string with multiple a characters");
+	assert(strchr(teststr, 'a') == teststr + 8);   // first 'a' at position 8
+	assert(strrchr(teststr, 'a') == teststr + 42);  // last 'a' at position 42
+	
+	// Test with character not found in long string
+	assert(strchr(teststr, 'z') == nullptr);
+	assert(strrchr(teststr, 'z') == nullptr);
+	
+	// Test with first and last character
+	strcpy(teststr, "abcdefghijklmnopqrstuvwxyza");
+	assert(strchr(teststr, 'a') == teststr);        // first character
+	assert(strrchr(teststr, 'a') == teststr + 26);  // last character
+	
+	// Build a long test string with pattern
+	for(int i = 0; i < 1000; i++)
+	{
+		teststr[i] = 'a' + (i % 26);
+	}
+	teststr[1000] = '\0';
+	
+	// Test strchr and strrchr with pattern
+	assert(strchr(teststr, 'a') == teststr);        // first 'a' at start
+	assert(strchr(teststr, 'z') == teststr + 25);   // first 'z' at position 25
+	assert(strrchr(teststr, 'a') == teststr + 988); // last 'a' at 988 (988 % 26 == 0)
+	assert(strrchr(teststr, 'z') == teststr + 987); // last 'z' at 987 (987 % 26 == 25)
+	
+	// Test with character that appears only once
+	strcpy(teststr, "abcdefghijklmnopqrstuvwxyz");
+	for(char c = 'a'; c <= 'z'; c++)
+	{
+		char *first = strchr(teststr, c);
+		char *last = strrchr(teststr, c);
+		assert(first == last);  // should be same for unique characters
+		assert(first != nullptr);
+		assert(*first == c);
+	}
+	
+	return 0;
+}

--- a/autotest/strcmptest2.c
+++ b/autotest/strcmptest2.c
@@ -24,5 +24,54 @@ int main(void)
 	assert(strcmp(aa, ba) < 0);
 	assert(strcmp(ba, aa) > 0);
 	
+	// Test strncmp with basic comparisons
+	assert(strncmp("abcdefgh", "abcdefgh", 8) == 0);
+	assert(strncmp("abcdefgh", "abcdemgh", 8) < 0);
+	assert(strncmp("abcdefgh", "abcdefghi", 8) == 0);  // only compare first 8 chars
+	assert(strncmp("abcdefghi", "abcdefgh", 9) > 0);
+	assert(strncmp("abcdemgh", "abcdefgh", 8) > 0);
+	
+	// Test strncmp with partial comparisons
+	assert(strncmp("abcdefgh", "abcdemgh", 4) == 0);  // first 4 chars are same
+	assert(strncmp("abcdefgh", "abcdemgh", 6) < 0);   // difference at 5th char
+	assert(strncmp("hello", "help", 3) == 0);         // "hel" vs "hel"
+	assert(strncmp("hello", "help", 4) < 0);          // "hell" vs "help"
+	
+	// Test strncmp with zero length
+	assert(strncmp("different", "strings", 0) == 0);  // zero length always equal
+	assert(strncmp("", "", 0) == 0);
+	assert(strncmp("a", "b", 0) == 0);
+	
+	// Test strncmp with empty strings
+	assert(strncmp("", "", 5) == 0);
+	assert(strncmp("hello", "", 5) > 0);
+	assert(strncmp("", "hello", 5) < 0);
+	assert(strncmp("hello", "", 1) > 0);
+	assert(strncmp("", "hello", 1) < 0);
+	
+	// Test strncmp with single characters
+	assert(strncmp("a", "a", 1) == 0);
+	assert(strncmp("a", "b", 1) < 0);
+	assert(strncmp("b", "a", 1) > 0);
+	
+	// Test strncmp where one string is shorter
+	assert(strncmp("abc", "abcdef", 3) == 0);
+	assert(strncmp("abc", "abcdef", 6) < 0);  // null vs 'd'
+	assert(strncmp("abcdef", "abc", 6) > 0);  // 'd' vs null
+	
+	// Test strncmp with long strings
+	strcpy(ba, aa);  // restore ba to match aa
+	assert(strncmp(aa, ba, 1900) == 0);
+	ba[1000] = 'z';
+	assert(strncmp(aa, ba, 1000) == 0);   // equal up to position 1000
+	assert(strncmp(aa, ba, 1001) < 0);    // difference at position 1000
+	assert(strncmp(ba, aa, 1001) > 0);    // difference at position 1000
+	assert(strncmp(aa, ba, 999) == 0);    // equal before the difference
+	
+	// Test strncmp with length larger than string length
+	strcpy(ba, "short");
+	assert(strncmp("short", ba, 100) == 0);  // equal even with large n
+	assert(strncmp("short", "shorx", 100) < 0);  // difference within string
+	
 	return 0;
 }

--- a/autotest/strcpytest.c
+++ b/autotest/strcpytest.c
@@ -1,0 +1,81 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+char dest[1025], src[1025];
+
+int main(void)
+{
+	strcpy(dest, "hello");
+	assert(strcmp(dest, "hello") == 0);
+
+	strcpy(dest, "");
+	assert(strcmp(dest, "") == 0);
+
+	strcpy(dest, "a");
+	assert(strcmp(dest, "a") == 0);
+
+	strcpy(dest, "abcdefghijklmnopqrstuvwxyz");
+	assert(strcmp(dest, "abcdefghijklmnopqrstuvwxyz") == 0);
+
+	// Test strcpy with long string
+	for (int i = 0; i < 1024; i++)
+	{
+		src[i] = 'a' + (i & 7);
+	}
+	src[1024] = 0;
+
+	strcpy(dest, src);
+	assert(strcmp(dest, src) == 0);
+
+	// Test strncpy with various lengths
+	strcpy(dest, "xxxxxxxxxx");
+	strncpy(dest, "hello", 5);
+	dest[5] = 0; // null terminate for comparison
+	assert(strcmp(dest, "hello") == 0);
+
+	strcpy(dest, "xxxxxxxxxx");
+	strncpy(dest, "hello", 3);
+	dest[3] = 0; // null terminate for comparison
+	assert(strcmp(dest, "hel") == 0);
+
+	strcpy(dest, "xxxxxxxxxx");
+	strncpy(dest, "hi", 5);
+	assert(dest[0] == 'h');
+	assert(dest[1] == 'i');
+	assert(dest[2] == 0);
+	assert(dest[3] == 0);
+	assert(dest[4] == 0);
+
+	// Test strncpy with exact length
+	strcpy(dest, "xxxxxxxxxx");
+	strncpy(dest, "test", 4);
+	dest[4] = 0; // null terminate for comparison
+	assert(strcmp(dest, "test") == 0);
+
+	// Test strncpy with zero length
+	strcpy(dest, "original");
+	strncpy(dest, "new", 0);
+	assert(strcmp(dest, "original") == 0);
+
+	// Test strncpy copying longer than source
+	strcpy(dest, "xxxxxxxxxx");
+	strncpy(dest, "ab", 8);
+	assert(dest[0] == 'a');
+	assert(dest[1] == 'b');
+	assert(dest[2] == 0);
+	assert(dest[3] == 0);
+	assert(dest[4] == 0);
+	assert(dest[5] == 0);
+	assert(dest[6] == 0);
+	assert(dest[7] == 0);
+
+	// Test strncpy with large string
+	strcpy(dest, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+	strncpy(dest, src, 1000);
+	dest[1000] = 0; // ensure null termination
+	src[1000] = 0;	// truncate source for comparison
+	assert(strcmp(dest, src) == 0);
+
+	return 0;
+}

--- a/autotest/strstrtest.c
+++ b/autotest/strstrtest.c
@@ -1,0 +1,100 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+char teststr[2000], substr[200];
+
+int main(void)
+{
+	// Test strstr with basic functionality
+	assert(strcmp(strstr("hello world", "hello"), "hello world") == 0);
+	assert(strcmp(strstr("hello world", "world"), "world") == 0);
+	assert(strcmp(strstr("hello world", "lo wo"), "lo world") == 0);
+	assert(strstr("hello world", "xyz") == nullptr);
+	
+	// Test strstr with empty substring
+	assert(strcmp(strstr("hello", ""), "hello") == 0);  // empty substring matches at start
+	assert(strcmp(strstr("", ""), "") == 0);
+	
+	// Test strstr with substring not found
+	assert(strstr("hello", "world") == nullptr);
+	assert(strstr("abc", "xyz") == nullptr);
+	assert(strstr("short", "longer") == nullptr);
+	
+	// Test strstr with single character substring
+	assert(strcmp(strstr("hello", "h"), "hello") == 0);
+	assert(strcmp(strstr("hello", "e"), "ello") == 0);
+	assert(strcmp(strstr("hello", "o"), "o") == 0);
+	assert(strstr("hello", "x") == nullptr);
+	
+	// Test strstr with substring at different positions
+	assert(strcmp(strstr("abcdefgh", "abc"), "abcdefgh") == 0);  // at start
+	assert(strcmp(strstr("abcdefgh", "def"), "defgh") == 0);     // in middle
+	assert(strcmp(strstr("abcdefgh", "fgh"), "fgh") == 0);       // at end
+	
+	// Test strstr with repeated patterns
+	assert(strcmp(strstr("ababab", "ab"), "ababab") == 0);       // finds first occurrence
+	assert(strcmp(strstr("ababab", "ba"), "babab") == 0);
+	assert(strcmp(strstr("ababab", "bab"), "babab") == 0);
+	
+	// Test strstr with overlapping patterns
+	assert(strcmp(strstr("aaaa", "aa"), "aaaa") == 0);           // finds first match
+	assert(strcmp(strstr("ababa", "aba"), "ababa") == 0);
+	
+	// Test strstr where substring equals the string
+	assert(strcmp(strstr("test", "test"), "test") == 0);
+	assert(strcmp(strstr("a", "a"), "a") == 0);
+	
+	// Test strstr with special characters
+	assert(strcmp(strstr("hello, world!", "o, w"), "o, world!") == 0);
+	assert(strcmp(strstr("a.b.c.d", ".b."), ".b.c.d") == 0);
+	assert(strcmp(strstr("x y z", " y "), " y z") == 0);
+	
+	// Build a long test string with pattern
+	for(int i = 0; i < 1900; i++)
+	{
+		teststr[i] = 'a' + (i & 7);
+	}
+	teststr[1900] = '\0';
+	
+	// Test strstr with long strings
+	strcpy(substr, "abcdefgh");
+	char *result = strstr(teststr, substr);
+	assert(result == teststr);  // pattern starts at beginning
+	assert(strncmp(result, substr, 8) == 0);
+	
+	// Test strstr with pattern that appears later
+	strcpy(substr, "bcdefgha");
+	result = strstr(teststr, substr);
+	assert(result == teststr + 1);  // pattern starts at position 1
+	assert(strncmp(result, substr, 8) == 0);
+	
+	// Test strstr with pattern not in string
+	strcpy(substr, "zzzzz");
+	assert(strstr(teststr, substr) == nullptr);
+	
+	// Test strstr with longer substring than string
+	strcpy(teststr, "short");
+	strcpy(substr, "this is longer");
+	assert(strstr(teststr, substr) == nullptr);
+	
+	// Test strstr with case sensitivity
+	assert(strstr("Hello", "hello") == nullptr);  // case sensitive
+	assert(strcmp(strstr("Hello", "Hello"), "Hello") == 0);
+	
+	// Test strstr with partial matches that fail
+	assert(strstr("abcde", "abcx") == nullptr);
+	assert(strstr("testing", "tester") == nullptr);
+	
+	// Test strstr with multiple occurrences (finds first)
+	strcpy(teststr, "the quick brown fox jumps over the lazy dog");
+	assert(strcmp(strstr(teststr, "the"), "the quick brown fox jumps over the lazy dog") == 0);
+	assert(strcmp(strstr(teststr, "o"), "own fox jumps over the lazy dog") == 0);  // first 'o'
+	
+	// Test strstr with whole word searches
+	assert(strcmp(strstr(teststr, "quick"), "quick brown fox jumps over the lazy dog") == 0);
+	assert(strcmp(strstr(teststr, "fox"), "fox jumps over the lazy dog") == 0);
+	assert(strcmp(strstr(teststr, "dog"), "dog") == 0);
+	
+	return 0;
+}

--- a/include/stdio.c
+++ b/include/stdio.c
@@ -1121,7 +1121,7 @@ char* fgets(char* s, int n, FILE* stream)
 int fputc(int c, FILE* stream)
 {
 	if (stream->fnum >= 0)
-		return krnio_putch(stream->fnum);
+		return krnio_putch(stream->fnum, c);
 	else
 	{
 		putpch(c);

--- a/include/stdlib.c
+++ b/include/stdlib.c
@@ -504,6 +504,42 @@ long labs(long n)
 	return n < 0 ? - n : n;	
 }
 
+div_t div(int numer, int denom)
+{
+	div_t result;
+
+	if (denom == 0)
+	{
+		result.quot = 0;
+		result.rem = 0;
+	}
+	else
+	{
+		result.quot = numer / denom;
+		result.rem = numer % denom;
+	}
+	
+	return result;
+}
+
+ldiv_t ldiv(long int numer, long int denom)
+{
+	ldiv_t result;
+
+	if (denom == 0)
+	{
+		result.quot = 0;
+		result.rem = 0;
+	}
+	else
+	{
+		result.quot = numer / denom;
+		result.rem = numer % denom;
+	}
+	
+	return result;
+}
+
 void exit(int status)
 {
 	__asm

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -3,6 +3,18 @@
 
 #define RAND_MAX	65535u
 
+typedef struct
+{
+	int quot;
+	int rem;
+} div_t;
+
+typedef struct
+{
+	long int quot;
+	long int rem;
+} ldiv_t;
+
 extern const float tpow10[7];
 
 void itoa(int n, char * s, unsigned radix);
@@ -35,6 +47,9 @@ int abs(int n);
 
 long labs(long n);
 
+div_t div(int numer, int denom);
+
+ldiv_t ldiv(long int numer, long int denom);
 
 void exit(int status);
 

--- a/include/string.c
+++ b/include/string.c
@@ -43,6 +43,24 @@ char * strcpy(char * dst, const char * src)
 
 #pragma native(strcpy)
 
+char * strncpy(char * dst, const char * src, int n)
+{
+	char * d = dst;
+	const char * s = src;
+
+	do {} while (n-- && (*d++ = *s++));
+
+	// If, after copying the terminating null character from src, count is not reached, 
+	// additional null characters are written to dest until the total of count characters 
+	// have been written.
+	while (n-- > 0)
+		*d++ = '\0';
+
+	return dst;
+}
+
+#pragma native(strncpy)
+
 #if 1
 
 int strcmp(const char * ptr1, const char * ptr2)
@@ -101,6 +119,31 @@ int strcmp(const char * ptr1, const char * ptr2)
 
 #pragma native(strcmp)
 
+int strncmp(const char * ptr1, const char * ptr2, int size)
+{
+	const char *p = ptr1, *q = ptr2;
+	char c = 0, d = 0;
+
+	while (size-- && (c = *p++) == (d = *q++))
+	{
+		if (!c)
+			return 0;
+	}
+
+	if (size < 0)
+		return 0; // equal up to size
+
+	if (c < d)
+		return -1;
+
+	if (c > d)
+		return 1;
+
+	return 0; // equal
+}
+
+#pragma native(strncmp)
+
 int strlen(const char * str)
 {
 	const char	*	s = str;
@@ -128,6 +171,33 @@ char * strcat(char * dst, const char * src)
 
 #pragma native(strcat)
 
+char * strncat(char * dst, const char * src, int n)
+{
+	char * d = dst;
+	const char * s = src;
+
+	while (*d)
+		d++;
+
+	while (1) {
+		if (!n--) {
+			// The terminating null character is always appended in the end
+			if (*d) {
+				*d = '\0'; 
+			}
+
+			return dst;
+		}
+
+		// stopping if the null character is found
+		if (!(*d++ = *s++)) {
+			return dst;
+		}
+	}
+}
+
+#pragma native(strncat)
+
 char * cpycat(char * dst, const char * src)
 {
 	while (*dst = *src++)
@@ -138,7 +208,7 @@ char * cpycat(char * dst, const char * src)
 
 #pragma native(cpycat)
 
-char* strchr( const char* str, int ch )
+char * strchr( const char * str, int ch )
 {
 	char * p = (char *)str;
 
@@ -151,6 +221,49 @@ char* strchr( const char* str, int ch )
 	return p;
 }
 
+char * strrchr(const char * str, int ch)
+{
+	const char * p = str;
+	const char * last = nullptr;
+
+	while (*p)
+	{
+		if (*p == (char)ch)
+			last = p;
+		p++;
+	}
+
+	// The terminating null character is considered to be a part of the string and can be found if searching for '\0'
+	return ch == '\0' ? (char *)p : (char *)last;
+}
+
+char * strstr(const char * str, const char * substr)
+{
+	const char * p = str;
+	const char * q = substr;
+
+	if (!*q)
+		return (char *)str; // empty substring matches at the start
+
+	while (*p)
+	{
+		const char * start = p;
+		q = substr;
+
+		while (*p && *q && *p == *q)
+		{
+			p++;
+			q++;
+		}
+
+		if (!*q) // reached end of substring
+			return (char *)start;
+
+		p = start + 1; // move to next character in str
+	}
+
+	return nullptr; // substring not found
+}
 
 void * memset(void * dst, int value, int size)
 {
@@ -252,7 +365,7 @@ void * memmove(void * dst, const void * src, int size)
 			do {
 				*--d = *--s;
 			} while (--sz);
-		}	
+		}
 	}
 	return dst;
 }
@@ -274,6 +387,18 @@ int memcmp(const void * ptr1, const void * ptr2, int size)
 	
 	return 0;
 }
-	
 
+void * memchr(const void * ptr, int ch, int size)
+{
+	const unsigned char * p = (const unsigned char *)ptr;
 
+	while (size--)
+	{
+		if (*p == (unsigned char)ch)
+			return (void *)p;
+
+		p++;
+	}
+
+	return nullptr; // not found
+}

--- a/include/string.h
+++ b/include/string.h
@@ -3,11 +3,23 @@
 
 char * strcpy(char * dst, const char * src);
 
+char * strncpy(char * dst, const char * src, int n);
+
 int strcmp(const char * ptr1, const char * ptr2);
+
+int strncmp(const char * ptr1, const char * ptr2, int n);
 
 int strlen(const char * str);
 
 char * strcat(char * dst, const char * src);
+
+char * strncat(char * dst, const char * src, int n);
+
+char * strchr(const char * str, int ch);
+
+char * strrchr(const char * str, int ch);
+
+char * strstr(const char * str, const char * substr);
 
 char * cpycat(char * dst, const char * src);
 
@@ -21,7 +33,7 @@ int memcmp(const void * ptr1, const void * ptr2, int size);
 
 void * memmove(void * dst, const void * src, int size);
 
-char* strchr( const char* str, int ch );
+void * memchr(const void * ptr, int ch, int size);
 
 #pragma intrinsic(strcpy)
 
@@ -34,4 +46,3 @@ char* strchr( const char* str, int ch );
 #pragma compile("string.c")
 
 #endif
-


### PR DESCRIPTION
I was implementing library tests for the benchmarks, but unfortunately some very crucial methods where missing in string.h. Decided to implement the missing methods. Tested the results carefully against the C standards. I hope you like the additions.

Additionally, I added the file name and line number to the assert for comfort. Please review the changes, I hope I have covered everything. The assert in assert.h is a macro, now. Unfortunately, this breaks some tests for specific optimization levels: `arraytestfloat.c`, `linetest.c`, and `opp_streamtest.cpp`. You can decide to drop this commit, but I think it's important to fix the optimizer issues.

Updated the rand() and srand() accoding to the standard. The random numbers are still quite random (have an uncommited test for this in my benchmarks), even when starting with seed 1. But that's really no important change. The important thing is, that the rand() should just return positive values (this was causing troubles when I implemented my string.h tests).

Finally I had an issue with the scanf function. All my benchmarks and tests are getting compiled with '-psci'. This causes duplicate cases in the switch op causing compile errors. The issue is not easy to resolve as noted in the commit. Implemented a workaround by replacing the switch with ifs. Unfortunately, the `sscanftest.c` has optimizer issues, too.

Can you please have a look at the optimizer issues before we consider merging this request?

Another interesting issue: I just saw, that you have a qsort test, but the implementation in stdlib is missing. Maybe you could use the implementation from the test for the stdlib?