### PR TITLE
fix: fallback runtime and include path

### DIFF
--- a/oscar64/oscar64.cpp
+++ b/oscar64/oscar64.cpp
@@ -597,8 +597,11 @@ int main2(int argc, const char** argv)
 					strcpy_s(crtFileNamePath, basePath);
 					strcat_s(crtFileNamePath, "include/oscar64/crt.h");
 
-					if (!fopen_s(&crtFile, crtFileNamePath, "r"))
+					if (!fopen_s(&crtFile, crtFileNamePath, "r")) {
+						strcpy_s(includePath, basePath);
 						strcat_s(includePath, "include/oscar64/");
+						compiler->mPreprocessor->AddPath(includePath);
+					}
 					else
 					{
 						printf("Could not locate Oscar64 includes under %s\n", basePath);


### PR DESCRIPTION
Found this while trying to package this for Nix. Without this patch, I have to manually pass in
```
-i=/nix/store/<...>-oscar64-1.32.263/include/oscar64 -rt=/nix/store/<...>-oscar64-1.32.263/include/oscar64/crt.c
```

Before this change, hitting this branch would result in the `includePath` being `<prefix>/includeinclude/oscar64`, and the newly appended path wasn't added to the Preprocessor.

Please let me know if this would break other things, I just tried to make it work for my system without a full understanding of the potential impact. Thanks for the cool project :)