### PR TITLE
add install for oscar64 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,3 +70,4 @@ set_target_properties(oscar64 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/Release
 )
 
+install(TARGETS oscar64 RUNTIME DESTINATION bin)


### PR DESCRIPTION
i want to be able to redirect target outputs to an external dir.  with this change:
```
cmake -DCMAKE_INSTALL_PREFIX=~/myproject/thirdparty/bin -DCMAKE_BUILD_TYPE=Release -GNinja
ninja
ninja install
```

puts the oscar64 binary in `~/myproject/thirdparty/bin`