### PR TITLE
build: use $PATH for install/mkdir/sed, link dbghelp on windows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,60 @@
+name: Run checks
+
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
+    branches: 
+      - main
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-24.04-arm
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: "${{ matrix.os }}"
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Start sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        env:
+          SCCACHE_GHA_ENABLED: true
+
+      - name: Set CXX var
+        run: |
+          case "$RUNNER_OS" in
+            "Linux") echo "CXX=g++" >> "$GITHUB_ENV" ;;
+            "macOS") echo "CXX=clang++" >> "$GITHUB_ENV" ;;
+            "Windows") echo "CXX=g++" >> "$GITHUB_ENV" ;;
+          esac
+
+      - name: Determine number of cores
+        run: |
+          CORES=2
+          case "$RUNNER_OS" in
+            "Linux") CORES="$(nproc)" ;;
+            "macOS") CORES="$(sysctl -n hw.ncpu)" ;;
+            "Windows") CORES="$NUMBER_OF_PROCESSORS" ;;
+            *) echo "Unknown OS, using default." ;;
+          esac
+          echo "NUMBER_OF_CORES=$CORES" >> "$GITHUB_ENV"
+          echo "Using $CORES cores"
+
+      - name: make compiler
+        run: make -C make -j "$NUMBER_OF_CORES" compiler CXX="sccache ${CXX}"
+
+      - name: make check
+        run: make -C make -j "$NUMBER_OF_CORES" check

--- a/make/makefile
+++ b/make/makefile
@@ -5,13 +5,13 @@ objects = $(patsubst $(project_dir)/oscar64/%.cpp,$(srcdir)/%.o,$(sources))
 
 CXX = c++
 CPPFLAGS = -g -O2 -std=c++11 -Wno-switch
-SED = /usr/bin/sed
+SED = sed
 REMOVE_FORCE_ALL = $(RM) --recursive --dir
 export OSCAR64_CC = $(project_dir)/bin/oscar64
 export OSCAR64_CFLAGS =
 export OSCAR64_CXX = $(project_dir)/bin/oscar64
-MKDIR_PARENT = /bin/mkdir -p -m 755
-INSTALL = /usr/bin/install
+MKDIR_PARENT = mkdir -p -m 755
+INSTALL = install
 INSTALL_PROGRAM = $(INSTALL) -m 755
 INSTALL_DATA = $(INSTALL) -m 644
 DESTDIR =
@@ -27,10 +27,10 @@ ifdef WINDIR
 
 	ifneq ($(findstring MINGW,$(UNAME_S)),)
 		# MinGW
-		linklibs = -lversion -lpthread
+		linklibs = -lversion -lpthread -ldbghelp
 	else
 		# Native Windows (MSVC or other)
-		linklibs = -lpthread
+		linklibs = -lpthread -ldbghelp
 	endif
 else
 	UNAME_S := $(shell uname -s)
@@ -108,6 +108,7 @@ install: compiler
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/opp/*.h $(project_dir)/include/opp/*.cpp) $(DESTDIR)$(includedir)/oscar64/opp
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/plus4/*.h $(project_dir)/include/plus4/*.c) $(DESTDIR)$(includedir)/oscar64/plus4
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/vic20/*.h $(project_dir)/include/vic20/*.c) $(DESTDIR)$(includedir)/oscar64/vic20
+	@$(MKDIR_PARENT) $(mandir)
 	$(INSTALL_DATA) $(project_dir)/oscar64.1 $(mandir)
 
 uninstall:


### PR DESCRIPTION
I think it's fair to assume that `/bin/` & `/usr/bin/` are on `$PATH`, not hard-coding the binary locations would mean I don't have to patch it here: https://github.com/nekowinston/nixpkgs/blob/458fe6bad1d3df5cc308d86862d8154c87e195ea/pkgs/by-name/os/oscar64/package.nix#L29-L32

Regarding linking `dbghelp` on Windows: without it, I ran into this error: https://github.com/nekowinston/oscar64/actions/runs/17712502263/job/50333048253 & it's already linked here https://github.com/drmortalwombat/oscar64/blob/07e8dae882daefec3123bd85d3e11a29a6693db2/oscar64/oscar64.vcxproj#L165

---

I added some GitHub CI to troubleshoot the cross-platform build issues & autotests, but I don't know if you want CI in this repo. :)
Here's the latest successful autotest run from my repo: https://github.com/nekowinston/oscar64/actions/runs/17715919194