### PR TITLE
build: fix makefile install target

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -96,24 +96,25 @@ install: compiler
 	@echo "Installing to" $(DESTDIR)$(prefix)
 	@$(MKDIR_PARENT) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) $(project_dir)/bin/oscar64 $(DESTDIR)$(bindir)
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/*.h $(project_dir)/include/*.c) $(DESTDIR)$(includedir)/oscar64
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/audio
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/audio
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/audio/*.h $(project_dir)/include/audio/*.c) $(DESTDIR)$(includedir)/oscar64/audio
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/c64
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/c64
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/c64/*.h $(project_dir)/include/c64/*.c) $(DESTDIR)$(includedir)/oscar64/c64
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/c128
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/c128
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/c128/*.h $(project_dir)/include/c128/*.c) $(DESTDIR)$(includedir)/oscar64/c128
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/cx16
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/cx16
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/cx16/*.h $(project_dir)/include/cx16/*.c) $(DESTDIR)$(includedir)/oscar64/cx16
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/gfx
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/gfx
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/gfx/*.h $(project_dir)/include/gfx/*.c) $(DESTDIR)$(includedir)/oscar64/gfx
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/nes
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/nes
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/nes/*.h $(project_dir)/include/nes/*.c) $(DESTDIR)$(includedir)/oscar64/nes
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/opp
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/opp
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/opp/*.h $(project_dir)/include/opp/*.cpp) $(DESTDIR)$(includedir)/oscar64/opp
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/plus4
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/plus4
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/plus4/*.h $(project_dir)/include/plus4/*.c) $(DESTDIR)$(includedir)/oscar64/plus4
-	@$(MKDIR_PARENT) $(DESDIR)$(includedir)/oscar64/vic20
+	@$(MKDIR_PARENT) $(DESTDIR)$(includedir)/oscar64/vic20
 	$(INSTALL_DATA) $(wildcard $(project_dir)/include/vic20/*.h $(project_dir)/include/vic20/*.c) $(DESTDIR)$(includedir)/oscar64/vic20
 	@$(MKDIR_PARENT) $(mandir)
 	$(INSTALL_DATA) $(project_dir)/oscar64.1 $(mandir)


### PR DESCRIPTION
There was a copy-pasted typo in the previous makefile commit, and the base `include/oscar64` output dir wasn't created first