### PR TITLE
Basic stdio file functions for PET

### DIFF
--- a/include/c64/kernalio.c
+++ b/include/c64/kernalio.c
@@ -200,9 +200,13 @@ BANKINLINE krnioerr krnio_status(void)
 {
 	return __asm
 	{
+#if defined(__CBMPET__)
+		lda ST
+#else
 		BANKIN
 		jsr $ffb7	: ->a		// readst
 		BANKOUT
+#endif
 		sta accu
 		lda #0
 		sta accu + 1
@@ -439,7 +443,7 @@ int krnio_read(char fnum, char * data, int num)
 		return i;
 	}
 	else
-		return -1;	
+		return -1;
 }
 
 #pragma native(krnio_read)


### PR DESCRIPTION
In this batch I have added fopen, fclose, fread and fwrite support.

I didn't test any other functions, like fseek, ftell, fscanf, fprintf and so on. But this will allow rudimentary file operations.

This is geared towards older PETs. I can only test on a Basic 4 3032 with 8050 attached.