### PR TITLE
Add F256K target machine support

### DIFF
--- a/include/conio.c
+++ b/include/conio.c
@@ -214,9 +214,9 @@ void iocharmap(IOCharMap chmap)
 // Reads/writes hardware cursor registers (0xD014/0xD016) for sync
 // with f256lib's textGotoXY().  Default 80x30 (textReset defaults).
 
-static char __f256k_color = (char)0xF0;
+static char f256k_color = (char)0xF0;
 
-static void __f256k_scroll(void)
+static void f256k_scroll(void)
 {
 	char *vram = VKY_TEXT_MEM;
 	unsigned i;
@@ -232,7 +232,7 @@ static void __f256k_scroll(void)
 	for (i = 0; i < 80u * 29u; i++)
 		vram[i] = vram[i + 80];
 	for (i = 80u * 29u; i < 80u * 30u; i++)
-		vram[i] = __f256k_color;
+		vram[i] = f256k_color;
 
 	mmu.io_ctrl = MMU_IO_PAGE0;
 }
@@ -248,7 +248,7 @@ void putrch(char c)
 
 	char *vram = VKY_TEXT_MEM;
 	mmu.io_ctrl = MMU_IO_PAGE3;
-	vram[pos] = __f256k_color;
+	vram[pos] = f256k_color;
 	mmu.io_ctrl = MMU_IO_PAGE2;
 	vram[pos] = c;
 
@@ -257,7 +257,7 @@ void putrch(char c)
 		cx = 0;
 		cy++;
 		if (cy >= 30) {
-			__f256k_scroll();
+			f256k_scroll();
 			cy = 29;
 		}
 	}
@@ -277,7 +277,7 @@ void putpch(char c)
 		unsigned cy = vky.crsr_y;
 		cy++;
 		if (cy >= 30) {
-			__f256k_scroll();
+			f256k_scroll();
 			cy = 29;
 		}
 		vky.crsr_x = 0;
@@ -460,7 +460,7 @@ void clrscr(void)
 	mmu.io_ctrl = MMU_IO_PAGE3;
 	vram = VKY_COLOR_MEM;
 	for (i = 0; i < 80u * 30u; i++)
-		vram[i] = __f256k_color;
+		vram[i] = f256k_color;
 	mmu.io_ctrl = MMU_IO_PAGE0;
 	vky.crsr_x = 0;
 	vky.crsr_y = 0;
@@ -517,7 +517,7 @@ void gotoxy(char cx, char cy)
 void textcolor(char c)
 {
 #if defined(__F256K__)
-	__f256k_color = (__f256k_color & 0x0F) | (c << 4);
+	f256k_color = (f256k_color & 0x0F) | (c << 4);
 #else
 	*(volatile char *)0x0286 = c;
 #endif
@@ -526,7 +526,7 @@ void textcolor(char c)
 void bgcolor(char c)
 {
 #if defined(__F256K__)
-	__f256k_color = (__f256k_color & 0xF0) | (c & 0x0F);
+	f256k_color = (f256k_color & 0xF0) | (c & 0x0F);
 #else
 	*(volatile char *)0xd021 = c;
 #endif
@@ -547,7 +547,7 @@ void revers(char r)
 {
 #if defined(__F256K__)
 	if (r)
-		__f256k_color = (__f256k_color >> 4) | (__f256k_color << 4);
+		f256k_color = (f256k_color >> 4) | (f256k_color << 4);
 #else
 	if (r)
 		putrch(18);

--- a/include/conio.c
+++ b/include/conio.c
@@ -218,7 +218,7 @@ static char __f256k_color = (char)0xF0;
 
 static void __f256k_scroll(void)
 {
-	volatile char *vram = VKY_TEXT_MEM;
+	char *vram = VKY_TEXT_MEM;
 	unsigned i;
 
 	mmu.io_ctrl = MMU_IO_PAGE2;
@@ -246,7 +246,7 @@ void putrch(char c)
 	unsigned cy = vky.crsr_y;
 	unsigned pos = cy * 80 + cx;
 
-	volatile char *vram = VKY_TEXT_MEM;
+	char *vram = VKY_TEXT_MEM;
 	mmu.io_ctrl = MMU_IO_PAGE3;
 	vram[pos] = __f256k_color;
 	mmu.io_ctrl = MMU_IO_PAGE2;
@@ -452,7 +452,7 @@ void putch(char c)
 void clrscr(void)
 {
 #if defined(__F256K__)
-	volatile char *vram = VKY_TEXT_MEM;
+	char *vram = VKY_TEXT_MEM;
 	unsigned i;
 	mmu.io_ctrl = MMU_IO_PAGE2;
 	for (i = 0; i < 80u * 30u; i++)

--- a/include/crt.c
+++ b/include/crt.c
@@ -192,6 +192,13 @@ w0:
 
 #elif defined(__ATARI__)
 
+#elif defined(__F256K__)
+		sei
+		cld
+		// Set I/O page 0
+		lda #$00
+		sta $01
+
 #elif defined(OSCAR_TARGET_NES)
 		sei
 		cld
@@ -324,7 +331,7 @@ bcode:
 #endif
 
 spexit:
-#if defined(__ATARI__) || defined(OSCAR_TARGET_NES)
+#if defined(__ATARI__) || defined(OSCAR_TARGET_NES) || defined(__F256K__)
 		jmp spexit
 #else
 		lda	#$4c

--- a/include/f256k/f256k.h
+++ b/include/f256k/f256k.h
@@ -1,0 +1,293 @@
+#ifndef F256K_H
+#define F256K_H
+
+// F256K Hardware Register Definitions for oscar64
+// Based on the F256 Hardware Reference Manual
+
+// ============================================================
+// MMU Registers
+// ============================================================
+
+#define MMU_MEM_CTRL    (*(volatile char *)0x0000)
+#define MMU_IO_CTRL     (*(volatile char *)0x0001)
+
+// MMU_MEM_CTRL bits
+#define MMU_EDIT_EN     0x80    // Enable MLUT editing
+#define MMU_EDIT_LUT0   0x00    // Edit MLUT 0
+#define MMU_EDIT_LUT1   0x10    // Edit MLUT 1
+#define MMU_EDIT_LUT2   0x20    // Edit MLUT 2
+#define MMU_EDIT_LUT3   0x30    // Edit MLUT 3
+#define MMU_ACT_LUT0    0x00    // Activate MLUT 0
+#define MMU_ACT_LUT1    0x01    // Activate MLUT 1
+#define MMU_ACT_LUT2    0x02    // Activate MLUT 2
+#define MMU_ACT_LUT3    0x03    // Activate MLUT 3
+
+// MMU_IO_CTRL bits
+#define MMU_IO_DISABLE  0x04    // Disable I/O, Bank 6 = RAM
+#define MMU_IO_PAGE0    0x00    // I/O page 0 (control registers)
+#define MMU_IO_PAGE1    0x01    // I/O page 1 (font memory)
+#define MMU_IO_PAGE2    0x02    // I/O page 2 (text character matrix)
+#define MMU_IO_PAGE3    0x03    // I/O page 3 (text color matrix)
+
+// MLUT editing registers (visible when MMU_EDIT_EN set)
+#define MMU_LUT         ((volatile char *)0x0008)
+
+// ============================================================
+// VICKY (TinyVicky) Master Control Registers
+// ============================================================
+
+#define VKY_MSTR_CTRL_0 (*(volatile char *)0xd000)
+#define VKY_MSTR_CTRL_1 (*(volatile char *)0xd001)
+
+// VKY_MSTR_CTRL_0 bits
+#define VKY_TEXT        0x01    // Enable text display
+#define VKY_OVRLY       0x02    // Overlay text on graphics
+#define VKY_GRAPH       0x04    // Enable graphics modes
+#define VKY_BITMAP      0x08    // Enable bitmap display
+#define VKY_TILE        0x10    // Enable tile display
+#define VKY_SPRITE      0x20    // Enable sprite display
+#define VKY_GAMMA       0x40    // Enable gamma correction
+
+// VKY_MSTR_CTRL_1 bits
+#define VKY_CLK_70      0x01    // 70Hz mode (vs 60Hz)
+#define VKY_DBL_X       0x02    // Double character width
+#define VKY_DBL_Y       0x04    // Double character height
+#define VKY_MON_SLP     0x08    // Monitor sleep
+#define VKY_FON_OVLY    0x10    // Font overlay mode
+#define VKY_FON_SET     0x20    // Font set selection (0 or 1)
+
+// Border control
+#define VKY_BRD_CTRL    (*(volatile char *)0xd004)
+#define VKY_BRD_COLOR_B (*(volatile char *)0xd005)
+#define VKY_BRD_COLOR_G (*(volatile char *)0xd006)
+#define VKY_BRD_COLOR_R (*(volatile char *)0xd007)
+#define VKY_BRD_X_SIZE  (*(volatile char *)0xd008)
+#define VKY_BRD_Y_SIZE  (*(volatile char *)0xd009)
+
+// Background color
+#define VKY_BKG_COLOR_B (*(volatile char *)0xd00d)
+#define VKY_BKG_COLOR_G (*(volatile char *)0xd00e)
+#define VKY_BKG_COLOR_R (*(volatile char *)0xd00f)
+
+// Cursor control
+#define VKY_CRSR_CTRL   (*(volatile char *)0xd010)
+#define VKY_CRSR_CHAR   (*(volatile char *)0xd012)
+#define VKY_CRSR_COLOR  (*(volatile char *)0xd013)
+#define VKY_CRSR_X_L    (*(volatile char *)0xd014)
+#define VKY_CRSR_X_H    (*(volatile char *)0xd015)
+#define VKY_CRSR_Y_L    (*(volatile char *)0xd016)
+#define VKY_CRSR_Y_H    (*(volatile char *)0xd017)
+
+// Text display memory (I/O page 2)
+#define VKY_TEXT_MEM    ((volatile char *)0xc000)
+
+// Text color memory (I/O page 3)
+#define VKY_COLOR_MEM   ((volatile char *)0xc000)
+
+// Text color LUTs (I/O page 0)
+#define VKY_TXT_FG_LUT  ((volatile char *)0xd800)
+#define VKY_TXT_BG_LUT  ((volatile char *)0xd840)
+
+// Font memory (I/O page 1)
+#define VKY_FONT0       ((volatile char *)0xc000)
+#define VKY_FONT1       ((volatile char *)0xc800)
+
+// ============================================================
+// Interrupt Controller
+// ============================================================
+
+#define INT_PENDING_0   (*(volatile char *)0xd660)
+#define INT_PENDING_1   (*(volatile char *)0xd661)
+#define INT_PENDING_2   (*(volatile char *)0xd662)
+
+#define INT_POLARITY_0  (*(volatile char *)0xd664)
+#define INT_POLARITY_1  (*(volatile char *)0xd665)
+#define INT_POLARITY_2  (*(volatile char *)0xd666)
+
+#define INT_EDGE_0      (*(volatile char *)0xd668)
+#define INT_EDGE_1      (*(volatile char *)0xd669)
+#define INT_EDGE_2      (*(volatile char *)0xd66a)
+
+#define INT_MASK_0      (*(volatile char *)0xd66c)
+#define INT_MASK_1      (*(volatile char *)0xd66d)
+#define INT_MASK_2      (*(volatile char *)0xd66e)
+
+// Interrupt Group 0 bits
+#define INT_VKY_SOF     0x01    // Start Of Frame
+#define INT_VKY_SOL     0x02    // Start Of Line
+#define INT_PS2_KBD     0x04    // PS/2 keyboard
+#define INT_PS2_MOUSE   0x08    // PS/2 mouse
+#define INT_TIMER_0     0x10    // Timer 0
+#define INT_TIMER_1     0x20    // Timer 1
+#define INT_CARTRIDGE   0x80    // Cartridge
+
+// Interrupt Group 1 bits
+#define INT_UART        0x01    // UART
+#define INT_RTC         0x10    // Real time clock
+#define INT_VIA0        0x20    // VIA 0
+#define INT_VIA1        0x40    // VIA 1 (F256K keyboard)
+#define INT_SDC_INS     0x80    // SD card insertion
+
+// ============================================================
+// PS/2 Interface
+// ============================================================
+
+#define PS2_CTRL        (*(volatile char *)0xd640)
+#define PS2_OUT         (*(volatile char *)0xd641)
+#define KBD_IN          (*(volatile char *)0xd642)
+#define MS_IN           (*(volatile char *)0xd643)
+#define PS2_STAT        (*(volatile char *)0xd644)
+
+// PS2_CTRL bits
+#define PS2_K_WR        0x01    // Keyboard write
+#define PS2_M_WR        0x02    // Mouse write
+#define PS2_KCLR        0x04    // Clear keyboard FIFO
+#define PS2_MCLR        0x08    // Clear mouse FIFO
+
+// PS2_STAT bits
+#define PS2_KEMP        0x01    // Keyboard FIFO empty
+#define PS2_MEMP        0x02    // Mouse FIFO empty
+
+// ============================================================
+// Timers
+// ============================================================
+
+#define TIMER0_CTRL     (*(volatile char *)0xd650)
+#define TIMER0_VALUE    ((volatile char *)0xd651)
+#define TIMER0_CMP      ((volatile char *)0xd654)
+
+#define TIMER1_CTRL     (*(volatile char *)0xd658)
+#define TIMER1_VALUE    ((volatile char *)0xd659)
+#define TIMER1_CMP      ((volatile char *)0xd65c)
+
+// Timer control bits
+#define TIMER_EN        0x01    // Enable timer
+#define TIMER_CLR       0x02    // Clear timer
+#define TIMER_LOAD      0x04    // Load compare value
+#define TIMER_UP        0x08    // Count up (vs down)
+#define TIMER_SCLR      0x10    // Auto-clear on compare
+
+// ============================================================
+// UART (16750-compatible)
+// ============================================================
+
+#define UART_RXD        (*(volatile char *)0xd630)
+#define UART_TXR        (*(volatile char *)0xd630)
+#define UART_IER        (*(volatile char *)0xd631)
+#define UART_ISR        (*(volatile char *)0xd632)
+#define UART_FCR        (*(volatile char *)0xd632)
+#define UART_LCR        (*(volatile char *)0xd633)
+#define UART_MCR        (*(volatile char *)0xd634)
+#define UART_LSR        (*(volatile char *)0xd635)
+#define UART_MSR        (*(volatile char *)0xd636)
+#define UART_SPR        (*(volatile char *)0xd637)
+
+// Baud rate divisor (DLAB=1)
+#define UART_DLL        (*(volatile char *)0xd630)
+#define UART_DLH        (*(volatile char *)0xd631)
+
+// LSR bits
+#define UART_LSR_DR     0x01    // Data ready
+#define UART_LSR_THRE   0x20    // Transmitter holding register empty
+
+// ============================================================
+// DMA Controller
+// ============================================================
+
+#define DMA_CTRL        (*(volatile char *)0xdf00)
+#define DMA_FILL_BYTE   (*(volatile char *)0xdf01)
+#define DMA_SRC_ADDR    ((volatile char *)0xdf04)
+#define DMA_DST_ADDR    ((volatile char *)0xdf08)
+#define DMA_COUNT       ((volatile char *)0xdf0c)
+#define DMA_HEIGHT      ((volatile char *)0xdf0e)
+#define DMA_SRC_STRIDE  ((volatile char *)0xdf10)
+#define DMA_DST_STRIDE  ((volatile char *)0xdf12)
+
+// DMA_CTRL bits
+#define DMA_ENABLE      0x01    // Enable DMA
+#define DMA_2D          0x02    // 2D operation
+#define DMA_FILL        0x04    // Fill (vs copy)
+#define DMA_INT_EN      0x08    // Interrupt on complete
+#define DMA_START       0x80    // Start transfer
+
+// ============================================================
+// System Control
+// ============================================================
+
+#define SYS0            (*(volatile char *)0xd6a0)
+#define SYS1            (*(volatile char *)0xd6a1)
+#define SYS_RST0        (*(volatile char *)0xd6a2)
+#define SYS_RST1        (*(volatile char *)0xd6a3)
+#define SYS_RNDL        (*(volatile char *)0xd6a4)
+#define SYS_RNDH        (*(volatile char *)0xd6a5)
+#define SYS_RND_CTRL    (*(volatile char *)0xd6a6)
+#define SYS_MID         (*(volatile char *)0xd6a7)
+
+// SYS0 bits
+#define SYS_PWR_LED     0x01    // Power LED
+#define SYS_SD_LED      0x02    // SD card LED
+#define SYS_BUZZ        0x10    // Buzzer control
+#define SYS_CAP_EN      0x20    // Capslock LED (F256K)
+#define SYS_RESET       0x80    // Software reset
+
+// RNG control bits
+#define SYS_RNG_EN      0x01    // Enable RNG
+#define SYS_RNG_SEED    0x02    // Load seed
+
+// Machine IDs
+#define MID_F256JR      0x02
+#define MID_F256K       0x12
+
+// ============================================================
+// VIA (65C22) Registers
+// ============================================================
+
+// VIA 0 (auxiliary I/O)
+#define VIA0_IORB       (*(volatile char *)0xdc00)
+#define VIA0_IORA       (*(volatile char *)0xdc01)
+#define VIA0_DDRB       (*(volatile char *)0xdc02)
+#define VIA0_DDRA       (*(volatile char *)0xdc03)
+#define VIA0_T1C_L      (*(volatile char *)0xdc04)
+#define VIA0_T1C_H      (*(volatile char *)0xdc05)
+#define VIA0_T1L_L      (*(volatile char *)0xdc06)
+#define VIA0_T1L_H      (*(volatile char *)0xdc07)
+#define VIA0_T2C_L      (*(volatile char *)0xdc08)
+#define VIA0_T2C_H      (*(volatile char *)0xdc09)
+#define VIA0_SDR        (*(volatile char *)0xdc0a)
+#define VIA0_ACR        (*(volatile char *)0xdc0b)
+#define VIA0_PCR        (*(volatile char *)0xdc0c)
+#define VIA0_IFR        (*(volatile char *)0xdc0d)
+#define VIA0_IER        (*(volatile char *)0xdc0e)
+#define VIA0_IORA2      (*(volatile char *)0xdc0f)
+
+// VIA 1 (keyboard, F256K only)
+#define VIA1_IORB       (*(volatile char *)0xdb00)
+#define VIA1_IORA       (*(volatile char *)0xdb01)
+#define VIA1_DDRB       (*(volatile char *)0xdb02)
+#define VIA1_DDRA       (*(volatile char *)0xdb03)
+#define VIA1_T1C_L      (*(volatile char *)0xdb04)
+#define VIA1_T1C_H      (*(volatile char *)0xdb05)
+#define VIA1_T1L_L      (*(volatile char *)0xdb06)
+#define VIA1_T1L_H      (*(volatile char *)0xdb07)
+#define VIA1_T2C_L      (*(volatile char *)0xdb08)
+#define VIA1_T2C_H      (*(volatile char *)0xdb09)
+#define VIA1_SDR        (*(volatile char *)0xdb0a)
+#define VIA1_ACR        (*(volatile char *)0xdb0b)
+#define VIA1_PCR        (*(volatile char *)0xdb0c)
+#define VIA1_IFR        (*(volatile char *)0xdb0d)
+#define VIA1_IER        (*(volatile char *)0xdb0e)
+#define VIA1_IORA2      (*(volatile char *)0xdb0f)
+
+// ============================================================
+// SD Card Controller
+// ============================================================
+
+#define SDC_BASE        ((volatile char *)0xdd00)
+
+// ============================================================
+// Integer Math Coprocessor
+// ============================================================
+
+#define MATH_BASE       ((volatile char *)0xde00)
+
+#endif // F256K_H

--- a/include/f256k/f256k.h
+++ b/include/f256k/f256k.h
@@ -16,8 +16,8 @@ typedef signed char	sbyte;
 
 struct MMU
 {
-	volatile byte	mem_ctrl;
-	volatile byte	io_ctrl;
+	volatile __memmap byte	mem_ctrl;
+	volatile __memmap byte	io_ctrl;
 };
 
 #define mmu	(*((struct MMU *)0x0000))
@@ -41,7 +41,7 @@ struct MMU
 #define MMU_IO_PAGE3    0x03    // I/O page 3 (text color matrix)
 
 // MLUT editing registers (visible when MMU_EDIT_EN set)
-#define MMU_LUT         ((volatile char *)0x0008)
+#define MMU_LUT         ((volatile __memmap char *)0x0008)
 
 // ============================================================
 // VICKY (TinyVicky) Master Control Registers
@@ -90,18 +90,18 @@ struct VKY
 #define VKY_FON_SET     0x20    // Font set selection (0 or 1)
 
 // Text display memory (I/O page 2)
-#define VKY_TEXT_MEM    ((volatile char *)0xc000)
+#define VKY_TEXT_MEM    ((char *)0xc000)
 
 // Text color memory (I/O page 3)
-#define VKY_COLOR_MEM   ((volatile char *)0xc000)
+#define VKY_COLOR_MEM   ((char *)0xc000)
 
 // Text color LUTs (I/O page 0)
-#define VKY_TXT_FG_LUT  ((volatile char *)0xd800)
-#define VKY_TXT_BG_LUT  ((volatile char *)0xd840)
+#define VKY_TXT_FG_LUT  ((char *)0xd800)
+#define VKY_TXT_BG_LUT  ((char *)0xd840)
 
 // Font memory (I/O page 1)
-#define VKY_FONT0       ((volatile char *)0xc000)
-#define VKY_FONT1       ((volatile char *)0xc800)
+#define VKY_FONT0       ((char *)0xc000)
+#define VKY_FONT1       ((char *)0xc800)
 
 // ============================================================
 // Interrupt Controller

--- a/include/f256k/f256k.h
+++ b/include/f256k/f256k.h
@@ -4,12 +4,23 @@
 // F256K Hardware Register Definitions for oscar64
 // Based on the F256 Hardware Reference Manual
 
+typedef unsigned char	byte;
+typedef unsigned int	word;
+typedef unsigned long	dword;
+
+typedef signed char	sbyte;
+
 // ============================================================
 // MMU Registers
 // ============================================================
 
-#define MMU_MEM_CTRL    (*(volatile char *)0x0000)
-#define MMU_IO_CTRL     (*(volatile char *)0x0001)
+struct MMU
+{
+	volatile byte	mem_ctrl;
+	volatile byte	io_ctrl;
+};
+
+#define mmu	(*((struct MMU *)0x0000))
 
 // MMU_MEM_CTRL bits
 #define MMU_EDIT_EN     0x80    // Enable MLUT editing
@@ -36,8 +47,30 @@
 // VICKY (TinyVicky) Master Control Registers
 // ============================================================
 
-#define VKY_MSTR_CTRL_0 (*(volatile char *)0xd000)
-#define VKY_MSTR_CTRL_1 (*(volatile char *)0xd001)
+struct VKY
+{
+	volatile byte	ctrl0;          // 0xD000
+	volatile byte	ctrl1;          // 0xD001
+	byte		_pad0[2];       // 0xD002-0xD003
+	volatile byte	brd_ctrl;       // 0xD004
+	volatile byte	brd_color_b;    // 0xD005
+	volatile byte	brd_color_g;    // 0xD006
+	volatile byte	brd_color_r;    // 0xD007
+	volatile byte	brd_x_size;     // 0xD008
+	volatile byte	brd_y_size;     // 0xD009
+	byte		_pad1[3];       // 0xD00A-0xD00C
+	volatile byte	bkg_color_b;    // 0xD00D
+	volatile byte	bkg_color_g;    // 0xD00E
+	volatile byte	bkg_color_r;    // 0xD00F
+	volatile byte	crsr_ctrl;      // 0xD010
+	byte		_pad2;          // 0xD011
+	volatile byte	crsr_char;      // 0xD012
+	volatile byte	crsr_color;     // 0xD013
+	volatile word	crsr_x;         // 0xD014-0xD015
+	volatile word	crsr_y;         // 0xD016-0xD017
+};
+
+#define vky	(*((struct VKY *)0xd000))
 
 // VKY_MSTR_CTRL_0 bits
 #define VKY_TEXT        0x01    // Enable text display
@@ -55,28 +88,6 @@
 #define VKY_MON_SLP     0x08    // Monitor sleep
 #define VKY_FON_OVLY    0x10    // Font overlay mode
 #define VKY_FON_SET     0x20    // Font set selection (0 or 1)
-
-// Border control
-#define VKY_BRD_CTRL    (*(volatile char *)0xd004)
-#define VKY_BRD_COLOR_B (*(volatile char *)0xd005)
-#define VKY_BRD_COLOR_G (*(volatile char *)0xd006)
-#define VKY_BRD_COLOR_R (*(volatile char *)0xd007)
-#define VKY_BRD_X_SIZE  (*(volatile char *)0xd008)
-#define VKY_BRD_Y_SIZE  (*(volatile char *)0xd009)
-
-// Background color
-#define VKY_BKG_COLOR_B (*(volatile char *)0xd00d)
-#define VKY_BKG_COLOR_G (*(volatile char *)0xd00e)
-#define VKY_BKG_COLOR_R (*(volatile char *)0xd00f)
-
-// Cursor control
-#define VKY_CRSR_CTRL   (*(volatile char *)0xd010)
-#define VKY_CRSR_CHAR   (*(volatile char *)0xd012)
-#define VKY_CRSR_COLOR  (*(volatile char *)0xd013)
-#define VKY_CRSR_X_L    (*(volatile char *)0xd014)
-#define VKY_CRSR_X_H    (*(volatile char *)0xd015)
-#define VKY_CRSR_Y_L    (*(volatile char *)0xd016)
-#define VKY_CRSR_Y_H    (*(volatile char *)0xd017)
 
 // Text display memory (I/O page 2)
 #define VKY_TEXT_MEM    ((volatile char *)0xc000)
@@ -96,21 +107,18 @@
 // Interrupt Controller
 // ============================================================
 
-#define INT_PENDING_0   (*(volatile char *)0xd660)
-#define INT_PENDING_1   (*(volatile char *)0xd661)
-#define INT_PENDING_2   (*(volatile char *)0xd662)
+struct IntCtrl
+{
+	volatile byte	pending[3];     // 0xD660-0xD662
+	byte		_pad0;          // 0xD663
+	volatile byte	polarity[3];    // 0xD664-0xD666
+	byte		_pad1;          // 0xD667
+	volatile byte	edge[3];        // 0xD668-0xD66A
+	byte		_pad2;          // 0xD66B
+	volatile byte	mask[3];        // 0xD66C-0xD66E
+};
 
-#define INT_POLARITY_0  (*(volatile char *)0xd664)
-#define INT_POLARITY_1  (*(volatile char *)0xd665)
-#define INT_POLARITY_2  (*(volatile char *)0xd666)
-
-#define INT_EDGE_0      (*(volatile char *)0xd668)
-#define INT_EDGE_1      (*(volatile char *)0xd669)
-#define INT_EDGE_2      (*(volatile char *)0xd66a)
-
-#define INT_MASK_0      (*(volatile char *)0xd66c)
-#define INT_MASK_1      (*(volatile char *)0xd66d)
-#define INT_MASK_2      (*(volatile char *)0xd66e)
+#define intctrl	(*((struct IntCtrl *)0xd660))
 
 // Interrupt Group 0 bits
 #define INT_VKY_SOF     0x01    // Start Of Frame
@@ -132,19 +140,24 @@
 // PS/2 Interface
 // ============================================================
 
-#define PS2_CTRL        (*(volatile char *)0xd640)
-#define PS2_OUT         (*(volatile char *)0xd641)
-#define KBD_IN          (*(volatile char *)0xd642)
-#define MS_IN           (*(volatile char *)0xd643)
-#define PS2_STAT        (*(volatile char *)0xd644)
+struct PS2
+{
+	volatile byte	ctrl;           // 0xD640
+	volatile byte	out;            // 0xD641
+	volatile byte	kbd_in;         // 0xD642
+	volatile byte	ms_in;          // 0xD643
+	volatile byte	stat;           // 0xD644
+};
 
-// PS2_CTRL bits
+#define ps2	(*((struct PS2 *)0xd640))
+
+// PS2 ctrl bits
 #define PS2_K_WR        0x01    // Keyboard write
 #define PS2_M_WR        0x02    // Mouse write
 #define PS2_KCLR        0x04    // Clear keyboard FIFO
 #define PS2_MCLR        0x08    // Clear mouse FIFO
 
-// PS2_STAT bits
+// PS2 stat bits
 #define PS2_KEMP        0x01    // Keyboard FIFO empty
 #define PS2_MEMP        0x02    // Mouse FIFO empty
 
@@ -152,13 +165,16 @@
 // Timers
 // ============================================================
 
-#define TIMER0_CTRL     (*(volatile char *)0xd650)
-#define TIMER0_VALUE    ((volatile char *)0xd651)
-#define TIMER0_CMP      ((volatile char *)0xd654)
+struct Timer
+{
+	volatile byte	ctrl;           // +0x00
+	volatile byte	value[3];       // +0x01-0x03
+	volatile byte	cmp[3];         // +0x04-0x06
+	byte		_pad;           // +0x07
+};
 
-#define TIMER1_CTRL     (*(volatile char *)0xd658)
-#define TIMER1_VALUE    ((volatile char *)0xd659)
-#define TIMER1_CMP      ((volatile char *)0xd65c)
+#define timer0	(*((struct Timer *)0xd650))
+#define timer1	(*((struct Timer *)0xd658))
 
 // Timer control bits
 #define TIMER_EN        0x01    // Enable timer
@@ -171,20 +187,19 @@
 // UART (16750-compatible)
 // ============================================================
 
-#define UART_RXD        (*(volatile char *)0xd630)
-#define UART_TXR        (*(volatile char *)0xd630)
-#define UART_IER        (*(volatile char *)0xd631)
-#define UART_ISR        (*(volatile char *)0xd632)
-#define UART_FCR        (*(volatile char *)0xd632)
-#define UART_LCR        (*(volatile char *)0xd633)
-#define UART_MCR        (*(volatile char *)0xd634)
-#define UART_LSR        (*(volatile char *)0xd635)
-#define UART_MSR        (*(volatile char *)0xd636)
-#define UART_SPR        (*(volatile char *)0xd637)
+struct UART
+{
+	volatile byte	data;           // 0xD630 (RXD/TXR, or DLL when DLAB=1)
+	volatile byte	ier;            // 0xD631 (IER, or DLH when DLAB=1)
+	volatile byte	isr;            // 0xD632 (ISR read / FCR write)
+	volatile byte	lcr;            // 0xD633
+	volatile byte	mcr;            // 0xD634
+	volatile byte	lsr;            // 0xD635
+	volatile byte	msr;            // 0xD636
+	volatile byte	spr;            // 0xD637
+};
 
-// Baud rate divisor (DLAB=1)
-#define UART_DLL        (*(volatile char *)0xd630)
-#define UART_DLH        (*(volatile char *)0xd631)
+#define uart	(*((struct UART *)0xd630))
 
 // LSR bits
 #define UART_LSR_DR     0x01    // Data ready
@@ -194,16 +209,24 @@
 // DMA Controller
 // ============================================================
 
-#define DMA_CTRL        (*(volatile char *)0xdf00)
-#define DMA_FILL_BYTE   (*(volatile char *)0xdf01)
-#define DMA_SRC_ADDR    ((volatile char *)0xdf04)
-#define DMA_DST_ADDR    ((volatile char *)0xdf08)
-#define DMA_COUNT       ((volatile char *)0xdf0c)
-#define DMA_HEIGHT      ((volatile char *)0xdf0e)
-#define DMA_SRC_STRIDE  ((volatile char *)0xdf10)
-#define DMA_DST_STRIDE  ((volatile char *)0xdf12)
+struct DMA
+{
+	volatile byte	ctrl;           // 0xDF00
+	volatile byte	fill_byte;      // 0xDF01
+	byte		_pad0[2];       // 0xDF02-0xDF03
+	volatile byte	src_addr[3];    // 0xDF04-0xDF06
+	byte		_pad1;          // 0xDF07
+	volatile byte	dst_addr[3];    // 0xDF08-0xDF0A
+	byte		_pad2;          // 0xDF0B
+	volatile word	count;          // 0xDF0C-0xDF0D
+	volatile word	height;         // 0xDF0E-0xDF0F
+	volatile word	src_stride;     // 0xDF10-0xDF11
+	volatile word	dst_stride;     // 0xDF12-0xDF13
+};
 
-// DMA_CTRL bits
+#define dma	(*((struct DMA *)0xdf00))
+
+// DMA ctrl bits
 #define DMA_ENABLE      0x01    // Enable DMA
 #define DMA_2D          0x02    // 2D operation
 #define DMA_FILL        0x04    // Fill (vs copy)
@@ -214,14 +237,19 @@
 // System Control
 // ============================================================
 
-#define SYS0            (*(volatile char *)0xd6a0)
-#define SYS1            (*(volatile char *)0xd6a1)
-#define SYS_RST0        (*(volatile char *)0xd6a2)
-#define SYS_RST1        (*(volatile char *)0xd6a3)
-#define SYS_RNDL        (*(volatile char *)0xd6a4)
-#define SYS_RNDH        (*(volatile char *)0xd6a5)
-#define SYS_RND_CTRL    (*(volatile char *)0xd6a6)
-#define SYS_MID         (*(volatile char *)0xd6a7)
+struct SysCtrl
+{
+	volatile byte	sys0;           // 0xD6A0
+	volatile byte	sys1;           // 0xD6A1
+	volatile byte	rst0;           // 0xD6A2
+	volatile byte	rst1;           // 0xD6A3
+	volatile byte	rnd_lo;         // 0xD6A4
+	volatile byte	rnd_hi;         // 0xD6A5
+	volatile byte	rnd_ctrl;       // 0xD6A6
+	volatile byte	mid;            // 0xD6A7
+};
+
+#define sysctl	(*((struct SysCtrl *)0xd6a0))
 
 // SYS0 bits
 #define SYS_PWR_LED     0x01    // Power LED
@@ -242,41 +270,28 @@
 // VIA (65C22) Registers
 // ============================================================
 
+struct VIA
+{
+	volatile byte	iorb;           // +0x00
+	volatile byte	iora;           // +0x01
+	volatile byte	ddrb;           // +0x02
+	volatile byte	ddra;           // +0x03
+	volatile word	t1c;            // +0x04-0x05
+	volatile word	t1l;            // +0x06-0x07
+	volatile word	t2c;            // +0x08-0x09
+	volatile byte	sdr;            // +0x0A
+	volatile byte	acr;            // +0x0B
+	volatile byte	pcr;            // +0x0C
+	volatile byte	ifr;            // +0x0D
+	volatile byte	ier;            // +0x0E
+	volatile byte	iora2;          // +0x0F
+};
+
 // VIA 0 (auxiliary I/O)
-#define VIA0_IORB       (*(volatile char *)0xdc00)
-#define VIA0_IORA       (*(volatile char *)0xdc01)
-#define VIA0_DDRB       (*(volatile char *)0xdc02)
-#define VIA0_DDRA       (*(volatile char *)0xdc03)
-#define VIA0_T1C_L      (*(volatile char *)0xdc04)
-#define VIA0_T1C_H      (*(volatile char *)0xdc05)
-#define VIA0_T1L_L      (*(volatile char *)0xdc06)
-#define VIA0_T1L_H      (*(volatile char *)0xdc07)
-#define VIA0_T2C_L      (*(volatile char *)0xdc08)
-#define VIA0_T2C_H      (*(volatile char *)0xdc09)
-#define VIA0_SDR        (*(volatile char *)0xdc0a)
-#define VIA0_ACR        (*(volatile char *)0xdc0b)
-#define VIA0_PCR        (*(volatile char *)0xdc0c)
-#define VIA0_IFR        (*(volatile char *)0xdc0d)
-#define VIA0_IER        (*(volatile char *)0xdc0e)
-#define VIA0_IORA2      (*(volatile char *)0xdc0f)
+#define via0	(*((struct VIA *)0xdc00))
 
 // VIA 1 (keyboard, F256K only)
-#define VIA1_IORB       (*(volatile char *)0xdb00)
-#define VIA1_IORA       (*(volatile char *)0xdb01)
-#define VIA1_DDRB       (*(volatile char *)0xdb02)
-#define VIA1_DDRA       (*(volatile char *)0xdb03)
-#define VIA1_T1C_L      (*(volatile char *)0xdb04)
-#define VIA1_T1C_H      (*(volatile char *)0xdb05)
-#define VIA1_T1L_L      (*(volatile char *)0xdb06)
-#define VIA1_T1L_H      (*(volatile char *)0xdb07)
-#define VIA1_T2C_L      (*(volatile char *)0xdb08)
-#define VIA1_T2C_H      (*(volatile char *)0xdb09)
-#define VIA1_SDR        (*(volatile char *)0xdb0a)
-#define VIA1_ACR        (*(volatile char *)0xdb0b)
-#define VIA1_PCR        (*(volatile char *)0xdb0c)
-#define VIA1_IFR        (*(volatile char *)0xdb0d)
-#define VIA1_IER        (*(volatile char *)0xdb0e)
-#define VIA1_IORA2      (*(volatile char *)0xdb0f)
+#define via1	(*((struct VIA *)0xdb00))
 
 // ============================================================
 // SD Card Controller

--- a/oscar64/CompilerTypes.h
+++ b/oscar64/CompilerTypes.h
@@ -32,6 +32,7 @@ static const uint64 COPT_TARGET_COPY = 1ULL << 36;
 static const uint64 COPT_TARGET_BIN = 1ULL << 37;
 static const uint64 COPT_TARGET_LZO = 1ULL << 38;
 static const uint64 COPT_TARGET_NES = 1ULL << 39;
+static const uint64 COPT_TARGET_PGZ = 1ULL << 40;
 
 static const uint64 COPT_VERBOSE = 1ULL << 48;
 static const uint64 COPT_VERBOSE2 = 1ULL << 49;
@@ -80,7 +81,8 @@ enum TargetMachine
 	TMACH_NES_MMC3,
 	TMACH_ATARI,
 	TMACH_X16,
-	TMACH_MEGA65
+	TMACH_MEGA65,
+	TMACH_F256K
 };
 
 

--- a/oscar64/Linker.h
+++ b/oscar64/Linker.h
@@ -291,6 +291,7 @@ public:
 	bool WriteLblFile(const char* filename);
 	bool WriteCrtFile(const char* filename, uint16 id, uint8 subtype, const char * cname);
 	bool WriteBinFile(const char* filename);
+	bool WritePgzFile(const char* filename);
 	bool WriteNesFile(const char* filename, TargetMachine machine);
 	bool WriteMlbFile(const char* filename, TargetMachine machine);
 	bool WriteDbjFile(FILE * file);
@@ -306,7 +307,7 @@ public:
 	GrowingArray<LinkerOverlay*>	mOverlays;
 	GrowingArray<uint32>			mBreakpoints;
 
-	uint8	mMemory[0x10000], mWorkspace[0x10000];
+	uint8	mMemory[0x80000], mWorkspace[0x10000];
 	uint8	mCartridge[64][0x10000];
 
 	bool	mCartridgeBankUsed[64];

--- a/oscar64/NativeCodeGenerator.cpp
+++ b/oscar64/NativeCodeGenerator.cpp
@@ -15192,27 +15192,29 @@ void NativeCodeBasicBlock::CallAssembler(InterCodeProcedure* proc, NativeCodePro
 	if (ins->mSrc[0].mTemp < 0)
 	{
 		uint32	flags = NCIF_LOWER | NCIF_UPPER;
-		if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_ARG_REG_A)
-		{
-			flags |= NCIF_USE_CPU_REG_A;
-			mIns.Push(NativeCodeInstruction(ins, ASMIT_LDA, ASMIM_ZERO_PAGE, BC_REG_FPARAMS));
-		}
-		if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_ARG_REG_X)
-			flags |= NCIF_USE_CPU_REG_X;
-		if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_ARG_REG_Y)
-			flags |= NCIF_USE_CPU_REG_Y;
-
 		uint32	pflags = 0;
-		if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_PRESERVE_REG_A)
-			pflags |= NCIF_PRESERVE_CPU_REG_A;
-		if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_PRESERVE_REG_X)
-			pflags |= NCIF_PRESERVE_CPU_REG_X;
-		if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_PRESERVE_REG_Y)
-			pflags |= NCIF_PRESERVE_CPU_REG_Y;
 
-		assert(ins->mSrc[0].mLinkerObject);
+		if (ins->mSrc[0].mLinkerObject)
+		{
+			if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_ARG_REG_A)
+			{
+				flags |= NCIF_USE_CPU_REG_A;
+				mIns.Push(NativeCodeInstruction(ins, ASMIT_LDA, ASMIM_ZERO_PAGE, BC_REG_FPARAMS));
+			}
+			if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_ARG_REG_X)
+				flags |= NCIF_USE_CPU_REG_X;
+			if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_ARG_REG_Y)
+				flags |= NCIF_USE_CPU_REG_Y;
 
-		if (ins->mCode == IC_ASSEMBLER && (proc->mCompilerOptions & COPT_OPTIMIZE_ASSEMBLER) && ins->mSrc[0].mLinkerObject->mSection == proc->mLinkerObject->mSection && !ins->mVolatile)
+			if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_PRESERVE_REG_A)
+				pflags |= NCIF_PRESERVE_CPU_REG_A;
+			if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_PRESERVE_REG_X)
+				pflags |= NCIF_PRESERVE_CPU_REG_X;
+			if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_PRESERVE_REG_Y)
+				pflags |= NCIF_PRESERVE_CPU_REG_Y;
+		}
+
+		if (ins->mCode == IC_ASSEMBLER && ins->mSrc[0].mLinkerObject && (proc->mCompilerOptions & COPT_OPTIMIZE_ASSEMBLER) && ins->mSrc[0].mLinkerObject->mSection == proc->mLinkerObject->mSection && !ins->mVolatile)
 		{
 			ExpandingArray<NativeCodeInstruction>	tains;
 
@@ -15307,7 +15309,7 @@ void NativeCodeBasicBlock::CallAssembler(InterCodeProcedure* proc, NativeCodePro
 		else
 			mIns.Push(NativeCodeInstruction(ins, ASMIT_JSR, ASMIM_ABSOLUTE, ins->mSrc[0].mIntConst, ins->mSrc[0].mLinkerObject, flags));
 
-		lf = ins->mSrc[0].mLinkerObject->mFlags;
+		lf = ins->mSrc[0].mLinkerObject ? ins->mSrc[0].mLinkerObject->mFlags : 0;
 	}
 	else
 	{

--- a/oscar64/oscar64.cpp
+++ b/oscar64/oscar64.cpp
@@ -565,6 +565,11 @@ int main2(int argc, const char** argv)
 			compiler->mTargetMachine = TMACH_ATARI;
 			compiler->AddDefine(Ident::Unique("__ATARI__"), "1");
 		}
+		else if (!strcmp(targetMachine, "f256k"))
+		{
+			compiler->mTargetMachine = TMACH_F256K;
+			compiler->AddDefine(Ident::Unique("__F256K__"), "1");
+		}
 		else
 			compiler->mErrors->Error(loc, EERR_COMMAND_LINE, "Invalid target machine option", targetMachine);
 
@@ -590,6 +595,11 @@ int main2(int argc, const char** argv)
 				break;
 			}
 			compiler->AddDefine(Ident::Unique("__NES__"), "1");
+		}
+		else if (compiler->mTargetMachine == TMACH_F256K)
+		{
+			compiler->mCompilerOptions |= COPT_TARGET_PGZ;
+			compiler->AddDefine(Ident::Unique("OSCAR_TARGET_PGZ"), "1");
 		}
 		else if (!strcmp(targetFormat, "prg"))
 		{


### PR DESCRIPTION
## Summary

Adds F256K (Foenix 256K) as a new target machine for oscar64 (`-tm=f256k`).

- New target machine type `f256k` in the compiler, linker, and code generator
- F256K-specific CRT startup (`include/crt.c`) with MMU initialization
- Hardware register header (`include/f256k/f256k.h`) with struct-based definitions for all F256K peripherals (MMU, VICKY, interrupt controller, PS/2, timers, UART, DMA, system control, VIA)
- `conio` support (`include/conio.c`) with direct VRAM text output, cursor tracking via hardware registers, and screen scrolling
- Uses `volatile __memmap` on MMU struct members (matching the C128 `mmu.h` pattern) so bank-switch writes act as compiler memory fences
- Video RAM, font memory, and color LUT pointers use no qualifier (bulk data, not hardware registers)

## Test plan

- [x] Build f256lib-oscar64 examples (cube, lines, overlay, sprites, tilemap)
- [x] Build f256lib-oscar64 doodles (77 projects)
- [x] Build f256lib-oscar64 tutorials (59 projects)
- [x] Hardware-test on F256K: examples, doodles, and tutorials with text, bitmap, graphics, sprite, and FAR memory paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)