### PR TITLE
CMake: install runtime includes and man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.15)
 # Project name and version
 project(oscar64 VERSION 1.0 LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 # Define the executable
 add_executable(oscar64)
 
@@ -70,4 +72,18 @@ set_target_properties(oscar64 PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/Release
 )
 
-install(TARGETS oscar64 RUNTIME DESTINATION bin)
+install(TARGETS oscar64 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Install oscar64 runtime include files to <prefix>/include/oscar64/
+# The compiler resolves this at runtime via fallback: basePath + "include/oscar64/crt.h"
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/oscar64
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.c"
+    PATTERN "*.cpp"
+)
+
+install(FILES oscar64.1
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+)


### PR DESCRIPTION
## Problem

After `cmake --install`, running oscar64 fails with:
`Could not locate Oscar64 includes under /usr/local/`

The CMake build only installs the binary — not the runtime include files that the compiler needs at runtime.

## Fix

Add install rules to CMakeLists.txt:
- Runtime includes (`*.h`, `*.c`, `*.cpp`) → `<prefix>/include/oscar64/`
- Man page → `<prefix>/share/man/man1/`
- Use `GNUInstallDirs` for portable install paths

This matches the existing `make install` behavior. The compiler already handles this layout via its fallback path (`basePath + "include/oscar64/crt.h"`), so no C++ changes are needed.