### PR TITLE
Fixes the return after store for constant local initialisation 

### DIFF
--- a/autotest/constlocaltest.c
+++ b/autotest/constlocaltest.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <stdbool.h>
+
+static int counter;
+
+static int read_const_local_twice(void)
+{
+	const int value = ++counter;
+	return value + value;
+}
+
+static bool update(unsigned char* value)
+{
+	const unsigned char before = *value;
+	const unsigned char after = before + 2;
+	const bool changed = after != before;
+
+	*value = after;
+	return changed;
+}
+
+int main(void)
+{
+	assert(read_const_local_twice() == 2);
+	assert(counter == 1);
+
+	unsigned char value = 7;
+	assert(update(&value));
+	assert(value == 9);
+
+	return 0;
+}

--- a/oscar64/Declaration.cpp
+++ b/oscar64/Declaration.cpp
@@ -609,7 +609,9 @@ Expression* Expression::ConstantDereference(Errors* errors, LinkerSection* dataS
 	{
 		if (mDecType->IsSimpleType())
 		{
-			if (mDecValue->mType == DT_VARIABLE && (mDecValue->mFlags & DTF_CONST) && mDecValue->mValue)
+			// A local initialization is executable code and must not be evaluated again at each use.
+			if (mDecValue->mType == DT_VARIABLE && (mDecValue->mFlags & DTF_CONST) &&
+				mDecValue->mValue && mDecValue->mValue->mType == EX_CONSTANT)
 				return mDecValue->mValue;
 			else if (mDecValue->mType == DT_VARIABLE_REF && (mDecValue->mFlags & DTF_CONST) && mDecValue->mBase->mValue && mDecValue->mBase->mValue->mType == EX_CONSTANT && mDecValue->mBase->mValue->mDecValue->mType == DT_CONST_STRUCT)
 			{


### PR DESCRIPTION
I've also added a regression test that both demonstrates the code that was failing and ensures that it doesn't reocurr. 