### PR TITLE
Fixes a function pointer callback triggering an ambiguous overload error

### DIFF
--- a/autotest/ambiguousoverload.c
+++ b/autotest/ambiguousoverload.c
@@ -1,0 +1,22 @@
+#include "ambiguousoverload.h"
+
+/**
+ * Regression test for function pointers in aggregate initialisers.
+ *
+ * This setup function must be in a different translation unit from clearView's definition and
+ * direct call (ambiguousoverload_trigger.c). The bug reused clearView's function declaration as an
+ * aggregate-initialiser list node and corrupted its overload chain. Parsing the definition in the
+ * other translation unit then made the otherwise unambiguous direct call fail.
+ *
+ * Holder reproduces the original ambiguous-overload diagnostic. The single-member CallbackHolder
+ * also covers the related initialiser-builder assertion. Both callbacks are invoked to verify that
+ * their aggregate initialisers contain the correct function address. The pragma in
+ * ambiguousoverload.h schedules the companion translation unit so this remains one autotest target.
+ */
+void setup(void)
+{
+	struct Holder holder = { .value = 1, .callback = clearView };
+	struct CallbackHolder callbackHolder = { .callback = clearView };
+	holder.callback();
+	callbackHolder.callback();
+}

--- a/autotest/ambiguousoverload.h
+++ b/autotest/ambiguousoverload.h
@@ -1,0 +1,20 @@
+#pragma once
+
+typedef void (*Callback)(void);
+
+struct Holder
+{
+	int value;
+	Callback callback;
+};
+
+struct CallbackHolder
+{
+	Callback callback;
+};
+
+void clearView(void);
+
+extern int clearViewCalls;
+
+#pragma compile("ambiguousoverload_trigger.c")

--- a/autotest/ambiguousoverload_trigger.c
+++ b/autotest/ambiguousoverload_trigger.c
@@ -1,0 +1,24 @@
+#include "ambiguousoverload.h"
+
+#include <assert.h>
+
+
+void setup(void);
+
+int clearViewCalls = 0;
+
+// Kept in this companion translation unit to exercise cross-unit merging.
+void clearView(void)
+{
+	clearViewCalls++;
+}
+
+int main(void)
+{
+	setup();
+	assert(clearViewCalls == 2);
+	// This direct call was incorrectly diagnosed as an ambiguous overload.
+	clearView();
+	assert(clearViewCalls == 3);
+	return 0;
+}

--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -1,5 +1,8 @@
 rem @echo off
 
+@call :test ambiguousoverload.c
+@if %errorlevel% neq 0 goto :error
+
 @call :test array2dtest.c
 @if %errorlevel% neq 0 goto :error
 

--- a/autotest/makefile
+++ b/autotest/makefile
@@ -1,4 +1,4 @@
-SRCS=$(filter-out opp_part1.cpp opp_part2.cpp, $(wildcard *.c *.cpp))
+SRCS=$(filter-out ambiguousoverload_trigger.c opp_part1.cpp opp_part2.cpp, $(wildcard *.c *.cpp))
 EXES=$(patsubst %.c,%,$(SRCS))
 EXES:=$(patsubst %.cpp,%,$(EXES))
 

--- a/oscar64/Parser.cpp
+++ b/oscar64/Parser.cpp
@@ -1713,7 +1713,16 @@ Declaration * Parser::CopyConstantInitializer(int offset, Declaration* dtype, Ex
 		}
 		else
 		{
-			if (dec->mType == DT_CONST_FLOAT)
+			if (dec->mType == DT_CONST_FUNCTION && dtype->mType == DT_TYPE_POINTER)
+			{
+				// Aggregate entries are linked through mNext, so do not reuse the function
+				// declaration itself as an initialiser entry.
+				Declaration* ndec = new Declaration(dec->mLocation, DT_CONST_POINTER);
+				ndec->mValue = exp;
+				ndec->mBase = dtype;
+				dec = ndec;
+			}
+			else if (dec->mType == DT_CONST_FLOAT)
 			{
 				if (dtype->IsIntegerType() || dtype->mType == DT_TYPE_POINTER)
 				{


### PR DESCRIPTION
The autotest needs to be in two separate files to trigger the bug I found in my code as it was from  a functor used in this manner. When in the same translation unit the bug would not trigger.