### PR TITLE
Fix segfault on call through function pointer cast from constant address

### DIFF
--- a/oscar64/NativeCodeGenerator.cpp
+++ b/oscar64/NativeCodeGenerator.cpp
@@ -15636,7 +15636,14 @@ void NativeCodeBasicBlock::CallAssembler(InterCodeProcedure* proc, NativeCodePro
 
 	uint32	lf = 0;
 
-	if (ins->mSrc[0].mTemp < 0)
+	if (ins->mSrc[0].mTemp < 0 && !ins->mSrc[0].mLinkerObject)
+	{
+		// Call through a function pointer cast from a constant address,
+		// e.g. ((void (*)(void))0x8004)() - there is no linker object to
+		// consult, so emit a plain absolute JSR to the constant target
+		mIns.Push(NativeCodeInstruction(ins, ASMIT_JSR, ASMIM_ABSOLUTE, ins->mSrc[0].mIntConst, nullptr, NCIF_LOWER | NCIF_UPPER));
+	}
+	else if (ins->mSrc[0].mTemp < 0)
 	{
 		uint32	flags = NCIF_LOWER | NCIF_UPPER;
 		if (ins->mSrc[0].mLinkerObject->mFlags & LOBJF_ARG_REG_A)


### PR DESCRIPTION
Calling a function through a pointer cast from a constant address crashes the compiler with SIGSEGV:

```c
int main(void) {
    ((void (*)(void))0x8004)();   // e.g. entry of an external engine blob
    return 0;
}
```

```
oscar64 -n -O2 -tf=prg t.c   ->   Segmentation fault
```

The same happens when the pointer goes through a variable (constant folding reaches the same path). Reproduced on current main (2e56d75) and on v1.32.271, Linux x64, all optimization levels.

**Cause:** `NativeCodeBasicBlock::CallAssembler` dereferences `ins->mSrc[0].mLinkerObject` without a null check (first at the `LOBJF_ARG_REG_A` flag test, NativeCodeGenerator.cpp:15642). A constant call target coming from a plain integer cast has no linker object — there is even an `assert(ins->mSrc[0].mLinkerObject)` further down that release builds compile out.

**Fix:** when the call target is constant and has no linker object, emit a plain absolute `JSR` to `mIntConst` (the `Assemble` path already fully supports `ASMIM_ABSOLUTE` with a null linker object). Return-value handling keeps the default zero-page ACCU convention (`lf = 0`).

**Verification:**
- repro compiles at -O0/-O1/-O2/-O3/-Os, generated code is `20 04 80  JSR $8004`
- variable-pointer variant compiles and folds to the same direct `JSR`
- full autotest suite: 1086 compile+emulation runs, all `Emulation result 0`, no regressions