### PR TITLE
Fixed optimizer warning 2007 for by-value struct fields forwarded

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -309,11 +309,32 @@ rem @echo off
 @call :test structconditionaltest.c
 @if %errorlevel% neq 0 goto :error
 
+@call :testoptimizerlock optimizerstructvarargtest.c
+@if %errorlevel% neq 0 goto :error
+
 @exit /b 0
 
 :error
 echo Failed with error #%errorlevel%.
 exit /b %errorlevel%
+
+:testoptimizerlock
+..\bin\oscar64 -ea -g -n %~1 > optimizerstructvarargtest.log 2>&1
+@set compile_error=%errorlevel%
+@if %compile_error% neq 0 (
+	@type optimizerstructvarargtest.log
+	@del optimizerstructvarargtest.log
+	@exit /b %compile_error%
+)
+@findstr /c:"warning 2007:" /c:"Oops 31" optimizerstructvarargtest.log > nul
+@if %errorlevel% equ 0 (
+	@type optimizerstructvarargtest.log
+	@del optimizerstructvarargtest.log
+	@exit /b 1
+)
+@del optimizerstructvarargtest.log
+@call :test %~1
+@exit /b %errorlevel%
 
 :testh
 ..\bin\oscar64 -ea -g -bc %~1

--- a/autotest/makefile
+++ b/autotest/makefile
@@ -28,6 +28,22 @@ all: $(EXES)
 	$(OSCAR64_CXX) -ea -g -O3 -bc $<
 	$(OSCAR64_CXX) -ea -g -O3 -n $<
 
+optimizerstructvarargtest: optimizerstructvarargtest.c
+	@output="$$($(OSCAR64_CC) -ea -g -n $< 2>&1)"; status=$$?; \
+	if [ $$status -ne 0 ] || printf '%s\n' "$$output" | grep -Eq "warning 2007:|Oops 31"; then \
+		printf '%s\n' "$$output"; exit 1; \
+	fi
+	$(OSCAR64_CC) -ea -g -bc $<
+	$(OSCAR64_CC) -ea -g -n $<
+	$(OSCAR64_CC) -ea -g -O2 -bc $<
+	$(OSCAR64_CC) -ea -g -O2 -n $<
+	$(OSCAR64_CC) -ea -g -O0 -bc $<
+	$(OSCAR64_CC) -ea -g -O0 -n $<
+	$(OSCAR64_CC) -ea -g -Os -bc $<
+	$(OSCAR64_CC) -ea -g -Os -n $<
+	$(OSCAR64_CC) -ea -g -O3 -bc $<
+	$(OSCAR64_CC) -ea -g -O3 -n $<
+
 # testb
 bitshifttest: bitshifttest.c
 	$(OSCAR64_CC) -ea -g -bc $<

--- a/autotest/optimizerstructvarargtest.c
+++ b/autotest/optimizerstructvarargtest.c
@@ -1,11 +1,6 @@
 /*
  * Regression test for optimizer warning 2007 with fields of a by-value struct
  * forwarded to a variadic call.
- *
- * Run on POSIX with:
- *   make -C autotest optimizerstructvarargtest OSCAR64_CC=../bin/oscar64
- * The complete POSIX suite is run with: make -C make check
- * The Windows autotest.bat runner includes this test in its standard suite.
  */
 #include <assert.h>
 #include <stdint.h>

--- a/autotest/optimizerstructvarargtest.c
+++ b/autotest/optimizerstructvarargtest.c
@@ -1,0 +1,45 @@
+/*
+ * Regression test for optimizer warning 2007 with fields of a by-value struct
+ * forwarded to a variadic call.
+ *
+ * Run on POSIX with:
+ *   make -C autotest optimizerstructvarargtest OSCAR64_CC=../bin/oscar64
+ * The complete POSIX suite is run with: make -C make check
+ * The Windows autotest.bat runner includes this test in its standard suite.
+ */
+#include <assert.h>
+#include <stdint.h>
+
+struct ViewState
+{
+	uint16_t topLine;
+	uint16_t totalLines;
+	uint8_t visibleRows;
+};
+
+static volatile uint8_t sink;
+
+static void displayAt(const uint8_t row, ...)
+{
+	sink = row;
+}
+
+static void renderView(const struct ViewState state)
+{
+	displayAt(
+		23u,
+		state.topLine + 1u,
+		state.topLine + state.visibleRows > state.totalLines
+			? state.totalLines
+			: state.topLine + state.visibleRows,
+		state.totalLines
+	);
+}
+
+int main(void)
+{
+	const struct ViewState state = { 0u, 30u, 23u };
+	renderView(state);
+	assert(sink == 23u);
+	return 0;
+}

--- a/oscar64/NativeCodeGenerator.cpp
+++ b/oscar64/NativeCodeGenerator.cpp
@@ -27530,7 +27530,8 @@ bool NativeCodeBasicBlock::UntangleAbsoluteMoves(bool final)
 					}
 				}
 				else if (mIns[i + 0].mType == ASMIT_LDX && mIns[i + 0].mMode == ASMIM_ABSOLUTE && !(mIns[i + 0].mFlags & NCIF_VOLATILE) &&
-					mIns[i + 1].mType == ASMIT_STX && mIns[i + 1].mMode == ASMIM_ABSOLUTE && !(mIns[i + 1].mFlags & NCIF_VOLATILE) && (mIns[i + 1].mLive & LIVE_CPU_REG_A))
+					mIns[i + 1].mType == ASMIT_STX && mIns[i + 1].mMode == ASMIM_ABSOLUTE && !(mIns[i + 1].mFlags & NCIF_VOLATILE) &&
+					(mIns[i + 1].mLive & LIVE_CPU_REG_A) && !(mIns[i + 1].mLive & LIVE_CPU_REG_X))
 				{
 					int j = FindSafeMovePositionDown(i, i + 1, LIVE_CPU_REG_A | LIVE_CPU_REG_X | LIVE_CPU_REG_Z);
 					if (j > i + 2)
@@ -27552,9 +27553,7 @@ bool NativeCodeBasicBlock::UntangleAbsoluteMoves(bool final)
 					{
 						j = FindSafeMovePositionUp(i, i + 1, LIVE_CPU_REG_A | LIVE_CPU_REG_X | LIVE_CPU_REG_Z);
 
-						// Do not extend an X value that remains live after the store:
-						// the peephole shuffle would immediately move this pair back down.
-						if (j > 0 && j < i && !(mIns[i + 1].mLive & LIVE_CPU_REG_X))
+						if (j > 0 && j < i)
 						{
 							NativeCodeInstruction	lins = mIns[i + 0], sins = mIns[i + 1];
 							mIns.Remove(i, 2);
@@ -27615,7 +27614,8 @@ bool NativeCodeBasicBlock::UntangleAbsoluteMoves(bool final)
 					}
 				}
 				else if (mIns[i + 0].mType == ASMIT_LDY && mIns[i + 0].mMode == ASMIM_ABSOLUTE && !(mIns[i + 0].mFlags & NCIF_VOLATILE) &&
-					mIns[i + 1].mType == ASMIT_STY && mIns[i + 1].mMode == ASMIM_ABSOLUTE && !(mIns[i + 1].mFlags & NCIF_VOLATILE) && (mIns[i + 1].mLive & LIVE_CPU_REG_A))
+					mIns[i + 1].mType == ASMIT_STY && mIns[i + 1].mMode == ASMIM_ABSOLUTE && !(mIns[i + 1].mFlags & NCIF_VOLATILE) &&
+					(mIns[i + 1].mLive & LIVE_CPU_REG_A) && !(mIns[i + 1].mLive & LIVE_CPU_REG_Y))
 				{
 					int j = FindSafeMovePositionDown(i, i + 1, LIVE_CPU_REG_A | LIVE_CPU_REG_Y | LIVE_CPU_REG_Z);
 					if (j > i + 2)
@@ -27637,9 +27637,7 @@ bool NativeCodeBasicBlock::UntangleAbsoluteMoves(bool final)
 					{
 						j = FindSafeMovePositionUp(i, i + 1, LIVE_CPU_REG_A | LIVE_CPU_REG_Y | LIVE_CPU_REG_Z);
 
-						// Do not extend a Y value that remains live after the store:
-						// the peephole shuffle would immediately move this pair back down.
-						if (j > 0 && j < i && !(mIns[i + 1].mLive & LIVE_CPU_REG_Y))
+						if (j > 0 && j < i)
 						{
 							NativeCodeInstruction	lins = mIns[i + 0], sins = mIns[i + 1];
 							mIns.Remove(i, 2);

--- a/oscar64/NativeCodeGenerator.cpp
+++ b/oscar64/NativeCodeGenerator.cpp
@@ -27442,7 +27442,10 @@ bool NativeCodeBasicBlock::UntangleAbsoluteMoves(bool final)
 					else
 					{
 						j = FindSafeMovePositionUp(i, i + 1, LIVE_CPU_REG_A | LIVE_CPU_REG_X | LIVE_CPU_REG_Z);
-						if (j > 0 && j < i)
+
+						// Do not extend an X value that remains live after the store:
+						// the peephole shuffle would immediately move this pair back down.
+						if (j > 0 && j < i && !(mIns[i + 1].mLive & LIVE_CPU_REG_X))
 						{
 							NativeCodeInstruction	lins = mIns[i + 0], sins = mIns[i + 1];
 							mIns.Remove(i, 2);
@@ -27524,7 +27527,10 @@ bool NativeCodeBasicBlock::UntangleAbsoluteMoves(bool final)
 					else
 					{
 						j = FindSafeMovePositionUp(i, i + 1, LIVE_CPU_REG_A | LIVE_CPU_REG_Y | LIVE_CPU_REG_Z);
-						if (j > 0 && j < i)
+
+						// Do not extend a Y value that remains live after the store:
+						// the peephole shuffle would immediately move this pair back down.
+						if (j > 0 && j < i && !(mIns[i + 1].mLive & LIVE_CPU_REG_Y))
 						{
 							NativeCodeInstruction	lins = mIns[i + 0], sins = mIns[i + 1];
 							mIns.Remove(i, 2);
@@ -71770,4 +71776,3 @@ int  NativeCodeGenerator::FunctionCall::PotentialMatches(const FunctionCall* fc)
 
 	return match;
 }
-


### PR DESCRIPTION
Found this warning and cycle of `opps 31` messages. 