### PR TITLE
Fixes mixed-width native ternary corruption

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -309,6 +309,9 @@ rem @echo off
 @call :test structconditionaltest.c
 @if %errorlevel% neq 0 goto :error
 
+@call :test mixedwidthternary.c
+@if %errorlevel% neq 0 goto :error
+
 @exit /b 0
 
 :error

--- a/autotest/mixedwidthternary.c
+++ b/autotest/mixedwidthternary.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+enum
+{
+	healthDamageDivisor = 5u,
+	playerMaximumHealth = 17u,
+	expectedHealthDamage = 3u,
+	expectedRemainingHealth = playerMaximumHealth - expectedHealthDamage
+};
+
+enum WareItem
+{
+	WARE_ITEM__NONE,
+	WARE_ITEM__FOOD
+};
+
+struct Player
+{
+	uint8_t health;
+	uint8_t maxHealth;
+};
+
+static uint16_t calculateExtraDamage(uint8_t severity, uint16_t startDamage)
+{
+	if (severity == 0u)
+		return 0u;
+	return startDamage;
+}
+
+static uint8_t damagePlayer(struct Player * player, uint8_t severity)
+{
+	uint16_t intendedDamage = player->maxHealth / healthDamageDivisor;
+	intendedDamage += calculateExtraDamage(severity, intendedDamage);
+	const uint8_t healthDamage = player->health < intendedDamage
+		? player->health
+		: intendedDamage;
+	player->health -= healthDamage;
+	return healthDamage;
+}
+
+static enum WareItem consumeProvision(enum WareItem inventory[])
+{
+	if (inventory == NULL)
+		puts("Invalid inventory");
+
+	if (inventory[0] == WARE_ITEM__FOOD)
+	{
+		inventory[0] = WARE_ITEM__NONE;
+		return WARE_ITEM__FOOD;
+	}
+	return WARE_ITEM__NONE;
+}
+
+int main(void)
+{
+	struct Player player = { playerMaximumHealth, playerMaximumHealth };
+	enum WareItem inventory[1] = { WARE_ITEM__NONE };
+	consumeProvision(inventory);
+
+	const uint8_t healthDamage = damagePlayer(&player, 0u);
+	assert(healthDamage == expectedHealthDamage);
+	assert(player.health == expectedRemainingHealth);
+	return 0;
+}

--- a/oscar64/NativeCodeGenerator.cpp
+++ b/oscar64/NativeCodeGenerator.cpp
@@ -41448,6 +41448,10 @@ bool NativeCodeBasicBlock::CanZeroPageCopyUp(int at, int from, int to, bool diam
 {
 	bool full = at == mIns.Size();
 
+	// BackwardReplaceZeroPage follows only one predecessor for a diamond.
+	if (diamond && mEntryBlocks.Size() != 1)
+		return false;
+
 	mPatchChecked = true;
 
 	while (at > 0)
@@ -71770,4 +71774,3 @@ int  NativeCodeGenerator::FunctionCall::PotentialMatches(const FunctionCall* fc)
 
 	return match;
 }
-


### PR DESCRIPTION
This just disables the optimisation in the cases where it isn't guarenteed to be safe, it should leave the safe optimisations to continue to be performed.