### PR TITLE
Fixed an optimiser infinite loop for function-returned signed structures

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -312,10 +312,10 @@ rem @echo off
 @call :test structconditionaltest.c
 @if %errorlevel% neq 0 goto :error
 
-@call :testoptimizerlock optimizerstructvarargtest.c
+@call :test optimizerstructvarargtest.c
 @if %errorlevel% neq 0 goto :error
 
-@call :testoptimizerlock optimizerstructreturntest.c
+@call :test optimizerstructreturntest.c
 @if %errorlevel% neq 0 goto :error
 
 @call :test signedbytestructreturn.c
@@ -329,25 +329,6 @@ rem @echo off
 :error
 echo Failed with error #%errorlevel%.
 exit /b %errorlevel%
-
-:testoptimizerlock
-@set optimizer_lock_log=%~n1.log
-..\bin\oscar64 -ea -g -n %~1 > %optimizer_lock_log% 2>&1
-@set compile_error=%errorlevel%
-@if %compile_error% neq 0 (
-	@type %optimizer_lock_log%
-	@del %optimizer_lock_log%
-	@exit /b %compile_error%
-)
-@findstr /c:"warning 2007:" /c:"Oops " %optimizer_lock_log% > nul
-@if %errorlevel% equ 0 (
-	@type %optimizer_lock_log%
-	@del %optimizer_lock_log%
-	@exit /b 1
-)
-@del %optimizer_lock_log%
-@call :test %~1
-@exit /b %errorlevel%
 
 :testh
 ..\bin\oscar64 -ea -g -bc %~1

--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -315,6 +315,9 @@ rem @echo off
 @call :testoptimizerlock optimizerstructvarargtest.c
 @if %errorlevel% neq 0 goto :error
 
+@call :testoptimizerlock optimizerstructreturntest.c
+@if %errorlevel% neq 0 goto :error
+
 @call :test signedbytestructreturn.c
 @if %errorlevel% neq 0 goto :error
 
@@ -328,20 +331,21 @@ echo Failed with error #%errorlevel%.
 exit /b %errorlevel%
 
 :testoptimizerlock
-..\bin\oscar64 -ea -g -n %~1 > optimizerstructvarargtest.log 2>&1
+@set optimizer_lock_log=%~n1.log
+..\bin\oscar64 -ea -g -n %~1 > %optimizer_lock_log% 2>&1
 @set compile_error=%errorlevel%
 @if %compile_error% neq 0 (
-	@type optimizerstructvarargtest.log
-	@del optimizerstructvarargtest.log
+	@type %optimizer_lock_log%
+	@del %optimizer_lock_log%
 	@exit /b %compile_error%
 )
-@findstr /c:"warning 2007:" /c:"Oops 31" optimizerstructvarargtest.log > nul
+@findstr /c:"warning 2007:" /c:"Oops " %optimizer_lock_log% > nul
 @if %errorlevel% equ 0 (
-	@type optimizerstructvarargtest.log
-	@del optimizerstructvarargtest.log
+	@type %optimizer_lock_log%
+	@del %optimizer_lock_log%
 	@exit /b 1
 )
-@del optimizerstructvarargtest.log
+@del %optimizer_lock_log%
 @call :test %~1
 @exit /b %errorlevel%
 

--- a/autotest/makefile
+++ b/autotest/makefile
@@ -44,6 +44,22 @@ optimizerstructvarargtest: optimizerstructvarargtest.c
 	$(OSCAR64_CC) -ea -g -O3 -bc $<
 	$(OSCAR64_CC) -ea -g -O3 -n $<
 
+optimizerstructreturntest: optimizerstructreturntest.c
+	@output="$$($(OSCAR64_CC) -ea -g -n $< 2>&1)"; status=$$?; \
+	if [ $$status -ne 0 ] || printf '%s\n' "$$output" | grep -Eq "warning 2007:|Oops 10"; then \
+		printf '%s\n' "$$output"; exit 1; \
+	fi
+	$(OSCAR64_CC) -ea -g -bc $<
+	$(OSCAR64_CC) -ea -g -n $<
+	$(OSCAR64_CC) -ea -g -O2 -bc $<
+	$(OSCAR64_CC) -ea -g -O2 -n $<
+	$(OSCAR64_CC) -ea -g -O0 -bc $<
+	$(OSCAR64_CC) -ea -g -O0 -n $<
+	$(OSCAR64_CC) -ea -g -Os -bc $<
+	$(OSCAR64_CC) -ea -g -Os -n $<
+	$(OSCAR64_CC) -ea -g -O3 -bc $<
+	$(OSCAR64_CC) -ea -g -O3 -n $<
+
 # testb
 bitshifttest: bitshifttest.c
 	$(OSCAR64_CC) -ea -g -bc $<

--- a/autotest/makefile
+++ b/autotest/makefile
@@ -28,38 +28,6 @@ all: $(EXES)
 	$(OSCAR64_CXX) -ea -g -O3 -bc $<
 	$(OSCAR64_CXX) -ea -g -O3 -n $<
 
-optimizerstructvarargtest: optimizerstructvarargtest.c
-	@output="$$($(OSCAR64_CC) -ea -g -n $< 2>&1)"; status=$$?; \
-	if [ $$status -ne 0 ] || printf '%s\n' "$$output" | grep -Eq "warning 2007:|Oops 31"; then \
-		printf '%s\n' "$$output"; exit 1; \
-	fi
-	$(OSCAR64_CC) -ea -g -bc $<
-	$(OSCAR64_CC) -ea -g -n $<
-	$(OSCAR64_CC) -ea -g -O2 -bc $<
-	$(OSCAR64_CC) -ea -g -O2 -n $<
-	$(OSCAR64_CC) -ea -g -O0 -bc $<
-	$(OSCAR64_CC) -ea -g -O0 -n $<
-	$(OSCAR64_CC) -ea -g -Os -bc $<
-	$(OSCAR64_CC) -ea -g -Os -n $<
-	$(OSCAR64_CC) -ea -g -O3 -bc $<
-	$(OSCAR64_CC) -ea -g -O3 -n $<
-
-optimizerstructreturntest: optimizerstructreturntest.c
-	@output="$$($(OSCAR64_CC) -ea -g -n $< 2>&1)"; status=$$?; \
-	if [ $$status -ne 0 ] || printf '%s\n' "$$output" | grep -Eq "warning 2007:|Oops 10"; then \
-		printf '%s\n' "$$output"; exit 1; \
-	fi
-	$(OSCAR64_CC) -ea -g -bc $<
-	$(OSCAR64_CC) -ea -g -n $<
-	$(OSCAR64_CC) -ea -g -O2 -bc $<
-	$(OSCAR64_CC) -ea -g -O2 -n $<
-	$(OSCAR64_CC) -ea -g -O0 -bc $<
-	$(OSCAR64_CC) -ea -g -O0 -n $<
-	$(OSCAR64_CC) -ea -g -Os -bc $<
-	$(OSCAR64_CC) -ea -g -Os -n $<
-	$(OSCAR64_CC) -ea -g -O3 -bc $<
-	$(OSCAR64_CC) -ea -g -O3 -n $<
-
 # testb
 bitshifttest: bitshifttest.c
 	$(OSCAR64_CC) -ea -g -bc $<

--- a/autotest/optimizerstructreturntest.c
+++ b/autotest/optimizerstructreturntest.c
@@ -1,111 +1,46 @@
 /*
- * Regression test for optimiser warning 2007 when a small signed structure
- * returned by a function is used in wider co-ordinate arithmetic. The
- * generated X/Y transfer ranges used to move an immediate logic operation in
- * opposite directions and prevented the optimiser from reaching a fixed point.
+ * Regression test for optimiser warning 2007 when a returned signed structure
+ * is widened. The X/Y transfer rules used to prevent a fixed point.
  */
-#include <assert.h>
-#include <stdbool.h>
+#pragma warning(error: 2007)
+
 #include <stdint.h>
 
-struct CoordinateInt8
-{
-	int8_t column;
-	int8_t row;
-};
+typedef struct { int8_t x, y; } Vector;
+typedef struct { int16_t x, y; } Position;
 
-struct CoordinateInt16
-{
-	int16_t column;
-	int16_t row;
-};
-
-static uint8_t screenColumn;
-static uint8_t screenRow;
-static struct CoordinateInt16 position;
+static uint8_t screen;
+static Position position;
 static uint8_t speed = 1;
 
-static struct CoordinateInt8 makeCoordinateInt8(const int8_t column, const int8_t row)
+static Vector vector(int8_t x, int8_t y)
 {
-	return (struct CoordinateInt8){column, row};
+	return (Vector){x, y};
 }
 
-static bool moveTest(void)
+static int move(void)
 {
-	const struct CoordinateInt8 velocityVector = makeCoordinateInt8(
-		(int8_t)speed,
-		(int8_t)speed
-	);
-
-	if (velocityVector.column == 0 && velocityVector.row == 0)
+	Vector velocity = vector(speed, speed);
+	if (velocity.x == 0)
 		return speed != 0;
-	const struct CoordinateInt16 previousPosition = position;
-	bool didEnterScreen = false;
-	struct CoordinateInt16 nextPosition = {
-		position.column + velocityVector.column,
-		position.row + velocityVector.row
+	int entered = 0;
+	Position next = {
+		velocity.x,
+		position.y + velocity.y
 	};
 
-	if (nextPosition.column < 24)
-	{
-		if (screenColumn > 0)
-		{
-			--screenColumn;
-			nextPosition.column = 320;
-			didEnterScreen = true;
-		}
-		else
-			nextPosition.column = 24;
-	}
-	else if (nextPosition.column > 320)
-	{
-		if (screenColumn < 2)
-		{
-			++screenColumn;
-			nextPosition.column = 24;
-			didEnterScreen = true;
-		}
-		else
-			nextPosition.column = 320;
-	}
-
-	if (nextPosition.row < 50)
-	{
-		if (screenRow > 0)
-		{
-			--screenRow;
-			nextPosition.row = 229;
-			didEnterScreen = true;
-		}
-		else
-			nextPosition.row = 50;
-	}
-	else if (nextPosition.row > 229)
-	{
-		if (screenRow < 2)
-		{
-			++screenRow;
-			nextPosition.row = 50;
-			didEnterScreen = true;
-		}
-		else
-			nextPosition.row = 229;
-	}
-
-	if (!didEnterScreen)
-	{
-		if (
-			nextPosition.column == previousPosition.column &&
-			nextPosition.row == previousPosition.row
-		)
-			return false;
-	}
-	position = nextPosition;
-	return true;
+	if (!next.x && screen)
+		entered = 1;
+	if (!next.y)
+		next.y = 2;
+	else if (next.y > 2)
+		next.y = screen < 2 ? 1 : 2;
+	if (!entered && next.y == position.y)
+		return 0;
+	return 1;
 }
 
 int main(void)
 {
-	assert(moveTest());
-	return 0;
+	return !move();
 }

--- a/autotest/optimizerstructreturntest.c
+++ b/autotest/optimizerstructreturntest.c
@@ -1,0 +1,111 @@
+/*
+ * Regression test for optimiser warning 2007 when a small signed structure
+ * returned by a function is used in wider co-ordinate arithmetic. The
+ * generated X/Y transfer ranges used to move an immediate logic operation in
+ * opposite directions and prevented the optimiser from reaching a fixed point.
+ */
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct CoordinateInt8
+{
+	int8_t column;
+	int8_t row;
+};
+
+struct CoordinateInt16
+{
+	int16_t column;
+	int16_t row;
+};
+
+static uint8_t screenColumn;
+static uint8_t screenRow;
+static struct CoordinateInt16 position;
+static uint8_t speed = 1;
+
+static struct CoordinateInt8 makeCoordinateInt8(const int8_t column, const int8_t row)
+{
+	return (struct CoordinateInt8){column, row};
+}
+
+static bool moveTest(void)
+{
+	const struct CoordinateInt8 velocityVector = makeCoordinateInt8(
+		(int8_t)speed,
+		(int8_t)speed
+	);
+
+	if (velocityVector.column == 0 && velocityVector.row == 0)
+		return speed != 0;
+	const struct CoordinateInt16 previousPosition = position;
+	bool didEnterScreen = false;
+	struct CoordinateInt16 nextPosition = {
+		position.column + velocityVector.column,
+		position.row + velocityVector.row
+	};
+
+	if (nextPosition.column < 24)
+	{
+		if (screenColumn > 0)
+		{
+			--screenColumn;
+			nextPosition.column = 320;
+			didEnterScreen = true;
+		}
+		else
+			nextPosition.column = 24;
+	}
+	else if (nextPosition.column > 320)
+	{
+		if (screenColumn < 2)
+		{
+			++screenColumn;
+			nextPosition.column = 24;
+			didEnterScreen = true;
+		}
+		else
+			nextPosition.column = 320;
+	}
+
+	if (nextPosition.row < 50)
+	{
+		if (screenRow > 0)
+		{
+			--screenRow;
+			nextPosition.row = 229;
+			didEnterScreen = true;
+		}
+		else
+			nextPosition.row = 50;
+	}
+	else if (nextPosition.row > 229)
+	{
+		if (screenRow < 2)
+		{
+			++screenRow;
+			nextPosition.row = 50;
+			didEnterScreen = true;
+		}
+		else
+			nextPosition.row = 229;
+	}
+
+	if (!didEnterScreen)
+	{
+		if (
+			nextPosition.column == previousPosition.column &&
+			nextPosition.row == previousPosition.row
+		)
+			return false;
+	}
+	position = nextPosition;
+	return true;
+}
+
+int main(void)
+{
+	assert(moveTest());
+	return 0;
+}

--- a/autotest/optimizerstructvarargtest.c
+++ b/autotest/optimizerstructvarargtest.c
@@ -2,6 +2,8 @@
  * Regression test for optimizer warning 2007 with fields of a by-value struct
  * forwarded to a variadic call.
  */
+#pragma warning(error: 2007)
+
 #include <assert.h>
 #include <stdint.h>
 

--- a/oscar64.md
+++ b/oscar64.md
@@ -344,9 +344,11 @@ The compiler has various extensions to simplify developing for the C64.
 
 ## Pragmas
 
-Warnings can be turned on or off using the warning pragma.  The scope of the pragma is currently global in most cases, so if it is turned off at some place, it is off everywhere.
+Warnings can be disabled, restored to their default level, or promoted to errors using the warning pragma.  The scope of the pragma is currently global in most cases, so a change remains in effect everywhere that follows it.
 
 	#pragma warning(disable: 2000,2001)
+	#pragma warning(default: 2000,2001)
+	#pragma warning(error: 2007)
 
 A message can be displayed during compilation with the message pragma.  The message can be a list of values, such as constant strings or numbers that can be compiled at compile time.
 
@@ -1741,7 +1743,6 @@ The store is moved into the basic block that joins the two branches
 #### Peephole optimizations
 
 Various small and local optimizations are performed on the code on a per basic block level.
-
 
 
 

--- a/oscar64/Errors.cpp
+++ b/oscar64/Errors.cpp
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 Errors::Errors(void)
-	: mErrorCount(0), mMinLevel(EINFO_GENERIC), mDisabled(EERR_GENERIC)
+	: mErrorCount(0), mMinLevel(EINFO_GENERIC), mDisabled(EERR_GENERIC), mAsErrors(EERR_GENERIC)
 {
 
 }
@@ -32,7 +32,7 @@ void Errors::Error(const Location& loc, ErrorID eid, const char* msg, const char
 	if (eid >= mMinLevel && !(eid < EERR_GENERIC && mDisabled[eid]))
 	{
 		const char* level = "info";
-		if (eid >= EERR_GENERIC)
+		if (eid >= EERR_GENERIC || (eid >= EWARN_GENERIC && mAsErrors[eid]))
 		{
 
 			level = "error";
@@ -69,5 +69,3 @@ void Errors::Error(const Location& loc, ErrorID eid, const char* msg, const char
 			exit(20);
 	}
 }
-
-

--- a/oscar64/Errors.h
+++ b/oscar64/Errors.h
@@ -152,7 +152,7 @@ public:
 	int		mErrorCount;
 	ErrorID	mMinLevel;
 
-	NumberSet	mDisabled;
+	NumberSet	mDisabled, mAsErrors;
 
 	void Error(const Location& loc, ErrorID eid, const char* msg, const Ident* info1, const Ident* info2 = nullptr);
 	void Error(const Location& loc, ErrorID eid, const char* msg, const char* info1 = nullptr, const char* info2 = nullptr);

--- a/oscar64/NativeCodeGenerator.cpp
+++ b/oscar64/NativeCodeGenerator.cpp
@@ -38581,7 +38581,8 @@ bool NativeCodeBasicBlock::JoinTAYARange(int from, int to)
 	}
 	if (from >= 1)
 	{
-		if (mIns[from - 1].mMode == ASMIM_IMMEDIATE && !mIns[from - 1].RequiresCarry())
+		// Keep logic operations before transfer ranges so X/Y swapping cannot reverse this optimisation.
+		if (mIns[from - 1].mMode == ASMIM_IMMEDIATE && !mIns[from - 1].RequiresCarry() && !mIns[from - 1].IsLogic())
 		{
 			// Check special case for building high byte of 16 bit number from single signed byte
 			if (from >= 4 &&

--- a/oscar64/Parser.cpp
+++ b/oscar64/Parser.cpp
@@ -14668,7 +14668,7 @@ void Parser::ParsePragma(void)
 					if (ExpectToken(TK_INTEGER) && mScanner->mTokenInteger < EERR_GENERIC)
 					{
 						mErrors->mDisabled += int(mScanner->mTokenInteger);
-						mErrors->mAsErrors -= int(mScanner->mTokenInteger);
+						mErrors->mWarnErrors -= int(mScanner->mTokenInteger);
 						mScanner->NextToken();
 					}
 				} while (ConsumeTokenIf(TK_COMMA));
@@ -14680,7 +14680,7 @@ void Parser::ParsePragma(void)
 					if (ExpectToken(TK_INTEGER) && mScanner->mTokenInteger < EERR_GENERIC)
 					{
 						mErrors->mDisabled -= int(mScanner->mTokenInteger);
-						mErrors->mAsErrors += int(mScanner->mTokenInteger);
+						mErrors->mWarnErrors += int(mScanner->mTokenInteger);
 						mScanner->NextToken();
 					}
 				} while (ConsumeTokenIf(TK_COMMA));
@@ -14703,7 +14703,7 @@ void Parser::ParsePragma(void)
 					if (ExpectToken(TK_INTEGER) && mScanner->mTokenInteger < EERR_GENERIC)
 					{
 						mErrors->mDisabled -= int(mScanner->mTokenInteger);
-						mErrors->mAsErrors -= int(mScanner->mTokenInteger);
+						mErrors->mWarnErrors -= int(mScanner->mTokenInteger);
 						mScanner->NextToken();
 					}
 				} while (ConsumeTokenIf(TK_COMMA));

--- a/oscar64/Parser.cpp
+++ b/oscar64/Parser.cpp
@@ -14668,6 +14668,19 @@ void Parser::ParsePragma(void)
 					if (ExpectToken(TK_INTEGER) && mScanner->mTokenInteger < EERR_GENERIC)
 					{
 						mErrors->mDisabled += int(mScanner->mTokenInteger);
+						mErrors->mAsErrors -= int(mScanner->mTokenInteger);
+						mScanner->NextToken();
+					}
+				} while (ConsumeTokenIf(TK_COMMA));
+			}
+			else if (ConsumeIdentIf("error"))
+			{
+				ConsumeToken(TK_COLON);
+				do {
+					if (ExpectToken(TK_INTEGER) && mScanner->mTokenInteger < EERR_GENERIC)
+					{
+						mErrors->mDisabled -= int(mScanner->mTokenInteger);
+						mErrors->mAsErrors += int(mScanner->mTokenInteger);
 						mScanner->NextToken();
 					}
 				} while (ConsumeTokenIf(TK_COMMA));
@@ -14679,6 +14692,7 @@ void Parser::ParsePragma(void)
 					if (ExpectToken(TK_INTEGER) && mScanner->mTokenInteger < EERR_GENERIC)
 					{
 						mErrors->mDisabled -= int(mScanner->mTokenInteger);
+						mErrors->mAsErrors -= int(mScanner->mTokenInteger);
 						mScanner->NextToken();
 					}
 				} while (ConsumeTokenIf(TK_COMMA));


### PR DESCRIPTION
Encountered this while returning co-ordinate structures.