### PR TITLE
Fixes indexed-structure corruption across calls

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -336,6 +336,9 @@ rem @echo off
 @call :test strxcopy.c
 @if %errorlevel% neq 0 goto :error
 
+@call :test2 calleroffsettest.c calleroffsethelper.c
+@if %errorlevel% neq 0 goto :error
+
 @exit /b 0
 
 :error
@@ -452,6 +455,48 @@ exit /b %errorlevel%
 @if %errorlevel% neq 0 goto :error
 
 ..\bin\oscar64 -ea -g -O2 -Ox -n %~1
+@if %errorlevel% neq 0 goto :error
+
+@exit /b 0
+
+:test2
+..\bin\oscar64 -ea -g -bc %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -n %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O2 -bc %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O2 -n %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O0 -bc %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O0 -n %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -Os -bc %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -Os -n %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O3 -bc %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O3 -n %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O2 -xz -Oz -n %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O2 -Oo -n %~1 %~2
+@if %errorlevel% neq 0 goto :error
+
+..\bin\oscar64 -ea -g -O2 -Ox -n %~1 %~2
 @if %errorlevel% neq 0 goto :error
 
 @exit /b 0

--- a/autotest/calleroffsethelper.c
+++ b/autotest/calleroffsethelper.c
@@ -1,0 +1,14 @@
+#include "calleroffsethelper.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+__noinline long selectWithinRange(long minimum, long maximum)
+{
+	return minimum + rand() / (RAND_MAX / (maximum - minimum + 1) + 1);
+}
+
+inline char selectByte(char minimum, char maximum)
+{
+	return (char)selectWithinRange(minimum, maximum);
+}

--- a/autotest/calleroffsethelper.h
+++ b/autotest/calleroffsethelper.h
@@ -1,0 +1,3 @@
+#pragma once
+
+inline char selectByte(char minimum, char maximum);

--- a/autotest/calleroffsettest.c
+++ b/autotest/calleroffsettest.c
@@ -1,0 +1,82 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "calleroffsethelper.h"
+
+struct Position
+{
+	int column;
+	int row;
+};
+
+struct Item
+{
+	struct Position position;
+	unsigned char speed;
+	char heading;
+	unsigned char acceleration;
+	char accelerationHeading;
+	unsigned velocityRemainder;
+	unsigned displacementRemainder;
+	unsigned lastUpdate;
+	struct Position displayedPosition;
+	unsigned age;
+	unsigned delay;
+	unsigned char completedCount;
+	unsigned char hasClearedSource;
+	unsigned char isActive;
+};
+
+static struct Position sourcePosition;
+static struct Item items[4];
+static unsigned char processed[4];
+static const char selections[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+/* Keep a library-capable call in the graph so the caller reserves a sizeable
+ * volatile temporary area. */
+__noinline void recordItem(unsigned char index)
+{
+	if (processed[index] == 255)
+		printf("Unexpected item state\n");
+	processed[index] = 1;
+}
+
+/* The leading arguments make the run-time index arrive through the software
+ * stack, preserving the register-allocation shape which exposed the fault. */
+static void initialiseItem(long first, long second, long third, long fourth,
+	unsigned char index)
+{
+	(void)first;
+	(void)second;
+	(void)third;
+	(void)fourth;
+	struct Item * item = &items[index];
+	item->position = sourcePosition;
+	item->speed = 24;
+	item->heading = selections[(unsigned char)selectByte(0, 7)];
+	item->acceleration = 0;
+	item->accelerationHeading = 0;
+	item->velocityRemainder = 0;
+	item->displacementRemainder = 0;
+	item->lastUpdate = 0;
+	item->displayedPosition = item->position;
+	item->age = 0;
+	item->delay = 0;
+	item->completedCount = 0;
+	item->hasClearedSource = 0;
+	item->isActive = 1;
+	recordItem(index);
+}
+
+int main(void)
+{
+	sourcePosition.column = 300;
+	sourcePosition.row = 200;
+	srand(1);
+	initialiseItem(0, 0, 0, 0, 1);
+
+	return items[1].displayedPosition.column != 300
+		|| items[1].displayedPosition.row != 200
+		|| ! processed[1];
+}

--- a/autotest/makefile
+++ b/autotest/makefile
@@ -1,4 +1,5 @@
-SRCS=$(filter-out ambiguousoverload_trigger.c opp_part1.cpp opp_part2.cpp, $(wildcard *.c *.cpp))
+CALLER_OFFSET_SRCS=calleroffsettest.c calleroffsethelper.c
+SRCS=$(filter-out ambiguousoverload_trigger.c calleroffsethelper.c opp_part1.cpp opp_part2.cpp, $(wildcard *.c *.cpp))
 EXES=$(patsubst %.c,%,$(SRCS))
 EXES:=$(patsubst %.cpp,%,$(EXES))
 
@@ -16,6 +17,18 @@ diskimagefulltest:
 		printf 'Expected disk-capacity error and exit status 20, got %s\n' "$$status"; \
 		exit 1; \
 	fi
+
+calleroffsettest: $(CALLER_OFFSET_SRCS) calleroffsethelper.h
+	$(OSCAR64_CC) -ea -g -bc $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -n $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -O2 -bc $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -O2 -n $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -O0 -bc $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -O0 -n $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -Os -bc $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -Os -n $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -O3 -bc $(CALLER_OFFSET_SRCS)
+	$(OSCAR64_CC) -ea -g -O3 -n $(CALLER_OFFSET_SRCS)
 
 %: %.c
 	$(OSCAR64_CC) -ea -g -bc $<

--- a/oscar64/InterCode.cpp
+++ b/oscar64/InterCode.cpp
@@ -5254,6 +5254,14 @@ bool InterInstruction::RemoveUnusedResultInstructions(InterInstruction* pre, Num
 
 void InterInstruction::BuildCallerSaveTempSet(NumberSet& requiredTemps, NumberSet& callerSaveTemps)
 {
+	// Native address generation may retain an LEA index instead of its result.
+	// Preserve that index whenever the resulting address must survive a call.
+	if (mCode == IC_LEA && mDst.mTemp >= 0 && callerSaveTemps[mDst.mTemp])
+	{
+		for (int i = 0; i < mNumOperands; i++)
+			if (mSrc[i].mTemp >= 0) callerSaveTemps += mSrc[i].mTemp;
+	}
+
 	if (mDst.mTemp >= 0)
 		requiredTemps -= mDst.mTemp;
 


### PR DESCRIPTION
The 'calleroffsettest.c' and 'calleroffsethelper.c' cover a caller-save regression in
native address generation. The regression occurrs when all of the following
conditions were present:

- an array element address was calculated from a run-time index;
- a field was accessed through the resulting pointer before and after a call;
- native address optimisation retained the source byte offset instead of the
  pointer temporary; and
- the called procedure used the same caller-save scratch bytes.

The intermediate representation correctly classified the pointer as live across
the call, but did not give the same classification to the index from which native
code regenerated that pointer. The index could therefore be allocated in the
caller's volatile scratch area and overwritten by the called procedure. A later
structure copy then used the corrupted offset and copied the wrong array element.

The compiler now propagates caller-save status from an 'LEA' result to its source
temporaries. This preserves every value which native address generation may retain
when the address survives a call.