### PR TITLE
Fixes for WASI build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ else ()
     target_compile_options(oscar64 PRIVATE -Wall)
 endif ()
 
+# give WASI builds a bigger stack, 1 MB is too small
+if (CMAKE_SYSTEM_NAME STREQUAL "WASI")
+    target_link_options(oscar64 PRIVATE -Wl,-z,stack-size=16777216)
+endif ()
+
 # Post-build steps (only for Release builds)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_custom_command(TARGET oscar64 POST_BUILD

--- a/oscar64/Preprocessor.cpp
+++ b/oscar64/Preprocessor.cpp
@@ -821,7 +821,11 @@ bool SourceFile::Open(const char* name, const char* path, SourceFileMode mode)
 
 	if (!fopen_s(&mFile, fname, "rb"))
 	{
-		_fullpath(mFileName, fname, sizeof(mFileName));
+		char* fullPath = _fullpath(mFileName, fname, sizeof(mFileName));
+		// _fullpath might fail on WASI SDK which has no getcwd() except for "."
+		if (!fullPath || *fullPath == '\0') {
+			strcpy_s(mFileName, fname);
+		}
 		char* p = mFileName;
 		while (*p)
 		{


### PR DESCRIPTION
A bigger stack and a fix for _fullpath() are all that's needed for a [WASI build](https://8bitworkshop.com/latest/?platform=c64&file=particles.cpp)