### PR TITLE
RLE Compressioin Regression

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -339,6 +339,9 @@ rem @echo off
 @call :test calleroffsettest.c
 @if %errorlevel% neq 0 goto :error
 
+@call :test expandrletest.c
+@if %errorlevel% neq 0 goto :error
+
 @call :testn bitfieldstructinittest.cpp
 @if %errorlevel% neq 0 goto :error
 

--- a/autotest/expandrletest.c
+++ b/autotest/expandrletest.c
@@ -1,0 +1,30 @@
+#include <oscar.h>
+
+static const char expandRleTestEncoded[] =
+{
+	(char)0xa2,
+	(char)0x5a,
+	(char)0x11,
+	(char)0x22,
+	(char)0x33,
+	(char)0x00
+};
+
+int main(void)
+{
+	char output[6] = { 0 };
+
+	oscar_expand_rle(output, expandRleTestEncoded);
+
+	if ((unsigned char)output[0] != 0x5a ||
+		(unsigned char)output[1] != 0x5a ||
+		(unsigned char)output[2] != 0x5a ||
+		(unsigned char)output[3] != 0x11 ||
+		(unsigned char)output[4] != 0x22 ||
+		(unsigned char)output[5] != 0x33)
+	{
+		return 1;
+	}
+
+	return 0;
+}

--- a/oscar64/NativeCodeGenerator.cpp
+++ b/oscar64/NativeCodeGenerator.cpp
@@ -18072,7 +18072,8 @@ bool NativeCodeBasicBlock::ForwardZpYIndex(bool full)
 						changed = true;
 					}
 #if 1
-					else if (yoffset >= 2 && i + 1 < mIns.Size() && (k = InstructionRepeatCount(i + 1, ASMIT_INY)) >= yoffset - 2)
+					// The LDY and k INYs must provide enough slots for yoffset - k DEYs.
+					else if (yoffset >= 2 && i + 1 < mIns.Size() && (k = InstructionRepeatCount(i + 1, ASMIT_INY)) * 2 + 1 >= yoffset)
 					{
 						for (int j = ypred; j < i; j++)
 							mIns[j].mLive |= live;


### PR DESCRIPTION
The regression occurred when all of the following conditions were present:

- an array element address was calculated from a run-time index;
- a field was accessed through the resulting pointer before and after a call;
- native address optimisation retained the source byte offset instead of the
  pointer temporary; and
- the called procedure used the same caller-save scratch bytes.

The intermediate representation correctly classified the pointer as live across
the call, but did not give the same classification to the index from which native
code regenerated that pointer. The index could therefore be allocated in the
caller's volatile scratch area and overwritten by the called procedure. A later
structure copy then used the corrupted offset and copied the wrong array element.

The application-level helper and reordered selection logic were necessary because
they moved the call away from the live indexed address. They avoided the unsafe
lifetime overlap rather than correcting it, and are obsolete once the compiler
fix is in use.

The compiler now propagates caller-save status from an `LEA` result to its source
temporaries. This preserves every value which native address generation may retain
when the address survives a call.

Against the unfixed compiler, the native default build of this test returns `1`
and the autotest driver reports execution failure; against the fixed compiler it
returns `0`.
