### PR TITLE
Fixes Volitile Byte Comparison Bug

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -330,6 +330,9 @@ rem @echo off
 @call :test signedbytestructreturn.c
 @if %errorlevel% neq 0 goto :error
 
+@call :test volatilebytecomparison.c
+@if %errorlevel% neq 0 goto :error
+
 @call :test fixlogtest.c
 @if %errorlevel% neq 0 goto :error
 

--- a/autotest/volatilebytecomparison.c
+++ b/autotest/volatilebytecomparison.c
@@ -1,0 +1,46 @@
+/*
+ * Regression test for volatile byte comparison folding after passing a struct by value.
+ *
+ * An int16_t value wrapped inside a struct is passed by value, truncated to uint8_t,
+ * stored into a volatile byte location, and then read back and compared with the same
+ * truncated struct field value.
+ *
+ * When global constant propagation ran on intermediate code, relational operators
+ * copied forwarded integer constants without limiting their values to the operand
+ * type width. Consequently, a 16-bit constant (e.g. 300) was propagated into an 8-bit
+ * comparison operand, causing the compiler to incorrectly fold the volatile comparison
+ * to constant true and eliminate the runtime check.
+ */
+
+#include <stdint.h>
+
+struct SpriteColumnComparisonPosition
+{
+	int16_t column;
+};
+
+static volatile uint8_t hardwareRegister;
+
+static void positionSprite(const struct SpriteColumnComparisonPosition position)
+{
+	hardwareRegister = (uint8_t)position.column;
+}
+
+static int testVolatileByteComparison(void)
+{
+	const struct SpriteColumnComparisonPosition position = {
+		300
+	};
+
+	positionSprite(position);
+
+	if (hardwareRegister != (uint8_t)position.column)
+		return 1;
+
+	return 0;
+}
+
+int main(void)
+{
+	return testVolatileByteComparison();
+}

--- a/oscar64/InterCode.cpp
+++ b/oscar64/InterCode.cpp
@@ -5068,6 +5068,9 @@ bool InterInstruction::PropagateConstTemps(const GrowingInstructionPtrArray& cte
 				{
 					mSrc[i] = ains->mConst;
 					mSrc[i].mType = t;
+
+					if (IsIntegerType(mSrc[i].mType))
+						mSrc[i].mIntConst = LimitIntConstValue(mSrc[i].mType, mSrc[i].mIntConst);
 					changed = true;
 				}
 				else if (t == IT_POINTER && ains->mConst.mType == IT_INT16)
@@ -6186,6 +6189,25 @@ bool InterInstruction::ConstantFolding(void)
 				mConst.mIntConst = mSrc[0].mIntConst;
 				mConst.mLinkerObject = nullptr;
 				mConst.mOperandSize = 2;
+				mNumOperands = 0;
+				return true;
+			}
+			else if (IsIntegerType(mDst.mType) && IsIntegerType(mSrc[0].mType))
+			{
+				mCode = IC_CONSTANT;
+				mConst.mType = mDst.mType;
+				if (mDst.mType == IT_INT8)
+					mConst.mIntConst = (uint8)mSrc[0].mIntConst;
+				else if (mDst.mType == IT_INT16)
+					mConst.mIntConst = (uint16)mSrc[0].mIntConst;
+				else if (mDst.mType == IT_INT32)
+					mConst.mIntConst = (uint32)mSrc[0].mIntConst;
+				else if (mDst.mType == IT_BOOL)
+					mConst.mIntConst = mSrc[0].mIntConst != 0;
+				else
+					mConst.mIntConst = mSrc[0].mIntConst;
+				mConst.mLinkerObject = nullptr;
+				mConst.mOperandSize = InterTypeSize[mDst.mType];
 				mNumOperands = 0;
 				return true;
 			}
@@ -7524,6 +7546,27 @@ void InterCodeBasicBlock::CheckValueUsage(InterInstruction * ins, const GrowingI
 					ins->mSrc[0].mTemp = -1;
 					ins->mNumOperands = 0;
 				}
+			}
+		}
+		else if (TypeInteger(ins->mSrc[0].mType) && TypeInteger(ins->mDst.mType))
+		{
+			if (ins->mSrc[0].mTemp >= 0 && tvalue[ins->mSrc[0].mTemp] && tvalue[ins->mSrc[0].mTemp]->mCode == IC_CONSTANT)
+			{
+				ins->mCode = IC_CONSTANT;
+				ins->mConst.mType = ins->mDst.mType;
+				if (ins->mDst.mType == IT_INT8)
+					ins->mConst.mIntConst = (uint8)tvalue[ins->mSrc[0].mTemp]->mConst.mIntConst;
+				else if (ins->mDst.mType == IT_INT16)
+					ins->mConst.mIntConst = (uint16)tvalue[ins->mSrc[0].mTemp]->mConst.mIntConst;
+				else if (ins->mDst.mType == IT_INT32)
+					ins->mConst.mIntConst = (uint32)tvalue[ins->mSrc[0].mTemp]->mConst.mIntConst;
+				else if (ins->mDst.mType == IT_BOOL)
+					ins->mConst.mIntConst = tvalue[ins->mSrc[0].mTemp]->mConst.mIntConst != 0;
+				else
+					ins->mConst.mIntConst = tvalue[ins->mSrc[0].mTemp]->mConst.mIntConst;
+				ins->mConst.mOperandSize = InterTypeSize[ins->mDst.mType];
+				ins->mSrc[0].mTemp = -1;
+				ins->mNumOperands = 0;
 			}
 		}
 		break;


### PR DESCRIPTION
Updated InterInstruction::PropagateConstTemps in oscar64/InterCode.cpp to limit forwarded integer constant values via LimitIntConstValue according to the target operand type width for IC_RELATIONAL_OPERATOR.

Added the regression autotest autotest/volatilebytecomparison.c replicating the struct by-value parameter pass, volatile byte write/read, and byte comparison check across all optimisation levels.