### PR TITLE
Fixes an order-dependent rejection of valid pointer-to-const

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -339,6 +339,9 @@ rem @echo off
 @call :test calleroffsettest.c
 @if %errorlevel% neq 0 goto :error
 
+@call :test constconversionordertest.c
+@if %errorlevel% neq 0 goto :error
+
 @call :testn bitfieldstructinittest.cpp
 @if %errorlevel% neq 0 goto :error
 

--- a/autotest/constconversionordertest.c
+++ b/autotest/constconversionordertest.c
@@ -1,0 +1,19 @@
+/*
+ * Complete the type before the shared declarations, as in the original caller.
+ * The header queues the implementation before a later translation unit which
+ * redeclares both functions using its own incomplete structure declaration.
+ */
+struct ConstConversionOrderTimer
+{
+	unsigned secondsRemaining;
+};
+
+#include "constconversionordertest.h"
+
+int main(void)
+{
+	struct ConstConversionOrderTimer timer = { 0u };
+
+	constConversionOrderDisplay(&timer);
+	return 0;
+}

--- a/autotest/constconversionordertest.h
+++ b/autotest/constconversionordertest.h
@@ -1,0 +1,12 @@
+#ifndef CONST_CONVERSION_ORDER_TEST_H
+#define CONST_CONVERSION_ORDER_TEST_H
+
+struct ConstConversionOrderTimer;
+
+void constConversionOrderInvalidate(void);
+void constConversionOrderDisplay(const struct ConstConversionOrderTimer* const timer);
+
+#pragma compile("constconversionordertest_impl.c")
+#pragma compile("constconversionordertest_later.c")
+
+#endif

--- a/autotest/constconversionordertest_impl.c
+++ b/autotest/constconversionordertest_impl.c
@@ -1,0 +1,15 @@
+#include "constconversionordertest.h"
+
+struct ConstConversionOrderTimer
+{
+	unsigned secondsRemaining;
+};
+
+void constConversionOrderInvalidate(void)
+{
+}
+
+void constConversionOrderDisplay(const struct ConstConversionOrderTimer* const timer)
+{
+	(void)timer;
+}

--- a/autotest/constconversionordertest_later.c
+++ b/autotest/constconversionordertest_later.c
@@ -1,0 +1,6 @@
+#include "constconversionordertest.h"
+
+void constConversionOrderEnterScreen(void)
+{
+	constConversionOrderInvalidate();
+}

--- a/autotest/makefile
+++ b/autotest/makefile
@@ -1,4 +1,4 @@
-SRCS=$(filter-out ambiguousoverload_trigger.c opp_part1.cpp opp_part2.cpp, $(wildcard *.c *.cpp))
+SRCS=$(filter-out ambiguousoverload_trigger.c constconversionordertest_impl.c constconversionordertest_later.c opp_part1.cpp opp_part2.cpp, $(wildcard *.c *.cpp))
 EXES=$(patsubst %.c,%,$(SRCS))
 EXES:=$(patsubst %.cpp,%,$(EXES))
 

--- a/oscar64/Declaration.cpp
+++ b/oscar64/Declaration.cpp
@@ -2813,7 +2813,9 @@ bool Declaration::IsSubType(const Declaration* dec) const
 		return true;
 	else if (mType == DT_TYPE_STRUCT || mType == DT_TYPE_ENUM)
 	{
-		if (mScope == dec->mScope || (mIdent == dec->mIdent && mSize == dec->mSize))
+		// Matching structure tags remain compatible while either declaration is incomplete.
+		if (mScope == dec->mScope || (mIdent == dec->mIdent &&
+			(mSize == dec->mSize || (mIdent && mType == DT_TYPE_STRUCT && !(mFlags & dec->mFlags & DTF_DEFINED)))))
 			return true;
 
 		if (dec->mBase)


### PR DESCRIPTION
Found an issue with pointer to a const structure that seems to be due to Declaration::IsSubType incorrectly requiring equal structure sizes when comparing an incomplete tagged structure with its completed declaration. Then a later translation unit could therefore make a valid qualification conversion appear incompatible.

This changes the to match named structure tags that are now compatible while either declaration remains incomplete; completed structures must still have equal sizes.