### PR TITLE
Fixes Global Struct Snapshot Value Error

### DIFF
--- a/autotest/autotest.bat
+++ b/autotest/autotest.bat
@@ -342,6 +342,9 @@ rem @echo off
 @call :testn bitfieldstructinittest.cpp
 @if %errorlevel% neq 0 goto :error
 
+@call :test globalstructsnapshottest.c
+@if %errorlevel% neq 0 goto :error
+
 @exit /b 0
 
 :error

--- a/autotest/globalstructsnapshottest.c
+++ b/autotest/globalstructsnapshottest.c
@@ -1,0 +1,41 @@
+/*
+ * Regression test for global struct snapshot value forwarding across function calls.
+ *
+ * When an automatic local struct is initialised from a global struct and a subsequent
+ * function call modifies the global struct, reads from the local struct snapshot
+ * must not be incorrectly forwarded to the modified global struct.
+ */
+
+struct Position
+{
+	unsigned char column;
+	unsigned char row;
+};
+
+enum
+{
+	initialCoordinate = 0u,
+	movedColumn = 1u
+};
+
+static struct Position globalPosition = {
+	initialCoordinate,
+	initialCoordinate
+};
+
+static __noinline void movePlayer(void)
+{
+	globalPosition.column = movedColumn;
+}
+
+int main(void)
+{
+	const struct Position previousPosition = globalPosition;
+
+	movePlayer();
+
+	return (
+		previousPosition.column != globalPosition.column
+		|| previousPosition.row != globalPosition.row
+	) ? 0 : 1;
+}

--- a/oscar64/InterCode.cpp
+++ b/oscar64/InterCode.cpp
@@ -15159,34 +15159,43 @@ bool InterCodeBasicBlock::LoadStoreForwarding(const GrowingInstructionPtrArray& 
 						opmask = 3;
 
 					bool	flush = false;
-					for(int k=0; k<lins->mNumOperands; k++)
+					for(int opIdx=0; opIdx<lins->mNumOperands; opIdx++)
 					{
-						if ((1 << k) & opmask)
+						if ((1 << opIdx) & opmask)
 						{
-							InterOperand& op(lins->mSrc[k]);
+							InterOperand& op(lins->mSrc[opIdx]);
 
 							if (op.mTemp >= 0)
 							{
 								if (op.mMemoryBase == IM_GLOBAL)
-									flush = proc->ModifiesGlobal(op.mVarIndex);
+								{
+									if (proc->ModifiesGlobal(op.mVarIndex))
+										flush = true;
+								}
 								else if (op.mMemoryBase == IM_LOCAL && !mProc->mLocalVars[op.mVarIndex]->mAliased)
-									flush = false;
+									;
 								else if ((op.mMemoryBase == IM_PARAM || op.mMemoryBase == IM_FPARAM) && !mProc->mParamVars[op.mVarIndex]->mAliased)
-									flush = false;
-								else
-									flush = proc->mStoresIndirect;
+									;
+								else if (proc->mStoresIndirect)
+									flush = true;
 							}
 							else if (op.mMemory == IM_FFRAME || op.mMemory == IM_FRAME)
 								flush = true;
 							else if (op.mMemory == IM_GLOBAL)
-								flush = proc->ModifiesGlobal(op.mVarIndex);
+							{
+								if (proc->ModifiesGlobal(op.mVarIndex))
+									flush = true;
+							}
 							else if (op.mMemory == IM_LOCAL && !mProc->mLocalVars[op.mVarIndex]->mAliased)
-								flush = false;
+								;
 							else if ((op.mMemory == IM_PARAM || op.mMemory == IM_FPARAM) && !mProc->mParamVars[op.mVarIndex]->mAliased)
-								flush = false;
+								;
 							else
 								flush = true;
 						}
+
+						if (flush)
+							break;
 					}
 
 					if (!flush)


### PR DESCRIPTION
Updates InterCodeBasicBlock::LoadStoreForwarding to ensure that when checking instructions across procedure calls, finding a non-aliased local operand does not reset flush to false when a previous operand (such as a global struct source) was modified by the called procedure.

Fixes the improper value forwarding of copied global struct members across mutating function calls by correcting the operand invalidation logic in LoadStoreForwarding so that global modifications accurately invalidate copy instructions.

